### PR TITLE
Don't require username and password on heroku

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,16 +10,6 @@ var path = require('path'),
     password = process.env.PASSWORD,
     env = process.env.NODE_ENV || 'development';
 
-// Authenticate against the environment-provided credentials, if running
-// the app in production (Heroku, effectively)
-if (env === 'production') {
-  if (!username || !password) {
-    console.log('Username or password is not set, exiting.');
-    process.exit(1);
-  }
-  app.use(express.basicAuth(username, password));
-}
-
 // Application settings
 app.engine('html', swig.renderFile);
 app.set('view engine', 'html');


### PR DESCRIPTION
Let's circumvent our way round that problem by just not requiring this.

Everything's in Github anyway.
