### PR TITLE
Update appointment macro to appointment_summary

### DIFF
--- a/app/assets/sass/elements/_panels.scss
+++ b/app/assets/sass/elements/_panels.scss
@@ -30,21 +30,14 @@
 // NHS Panels
 // ==========================================================================
 
-// Link appointment panels
-.link-appointment {
+// Appointment summary panels
+.appointment-summary {
   display: block;
   max-width: 30em;
   padding: $gutter/3 $gutter/4;
   margin-bottom: $gutter;
   border: 4px solid #00855F;
   @extend %contain-floats;
-
-  &:focus,
-  &:hover {
-    background-color: $white;
-    border-color: $yellow;
-    outline: 3px solid $yellow;
-  }
 
   .heading-medium {
     margin-top: 0;
@@ -57,7 +50,14 @@
 
 }
 
-.link-appointment--secondary {
+a.appointment-summary:focus,
+a.appointment-summary:hover {
+  background-color: $white;
+  border-color: $yellow;
+  outline: 3px solid $yellow;
+}
+
+.appointment-summary--secondary {
   border-color: $grey-3;
   @include media(tablet) {
     font-size: inherit;
@@ -67,7 +67,7 @@
   }
 }
 
-.link-appointment__avatar {
+.appointment-summary__avatar {
   float: left;
   width: 35px;
   padding-right: $gutter/3;
@@ -77,7 +77,7 @@
   }
 }
 
-.link-appointment__info {
+.appointment-summary__info {
   float: left;
 }
 

--- a/app/views/book-an-appointment/next-appointment-with-woman.html
+++ b/app/views/book-an-appointment/next-appointment-with-woman.html
@@ -22,7 +22,7 @@
   <h2 class="heading-medium">Next available appointment with a woman GP:</h2>
 
   {{
-    ui_element_macros.link_appointment({
+    ui_element_macros.appointment_summary({
       link_url: 'appointment-confirmed',
       appointment_date: 'Friday 25th January 2016',
       appointment_time: '16:30',
@@ -35,8 +35,8 @@
   <h2 class="heading-small">Next available appointment:</h2>
 
   {{
-    ui_element_macros.link_appointment({
-      modifier_css_classes: 'link-appointment--secondary',
+    ui_element_macros.appointment_summary({
+      modifier_css_classes: 'appointment-summary--secondary',
       link_url: '#',
       appointment_date: 'Tuesday 23rd January 2016',
       appointment_time: '16:10',

--- a/app/views/book-an-appointment/next-available-appointment.html
+++ b/app/views/book-an-appointment/next-available-appointment.html
@@ -22,7 +22,7 @@
   <h2 class="heading-medium">Next available appointment:</h2>
 
   {{
-    ui_element_macros.link_appointment({
+    ui_element_macros.appointment_summary({
       link_url: '#',
       appointment_date: 'Tuesday 23rd January 2016',
       appointment_time: '16:10',

--- a/app/views/change-or-cancel-an-appointment/change-appointment.html
+++ b/app/views/change-or-cancel-an-appointment/change-appointment.html
@@ -13,7 +13,7 @@
 
   <h2 class="heading-medium">New appointment</h2>
   {{
-    ui_element_macros.link_appointment({
+    ui_element_macros.appointment_summary({
       appointment_date: 'Monday 28th January 2016',
       appointment_time: '11:00',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -24,13 +24,13 @@
 
   <h2 class="heading-medium">Old appointment</h2>
   {{
-    ui_element_macros.link_appointment({
+    ui_element_macros.appointment_summary({
       appointment_date: 'Friday 25th January 2016',
       appointment_time: '16:30',
       avatar_img_path: '/public/images/icon-avatar-helen-leaf.png',
       name: 'Dr. Helen Leaf',
       appointment_type: 'Face to face',
-      modifier_css_classes: 'link-appointment--secondary'
+      modifier_css_classes: 'appointment-summary--secondary'
     })
   }}
 

--- a/app/views/change-or-cancel-an-appointment/change-to-next-available-appointment.html
+++ b/app/views/change-or-cancel-an-appointment/change-to-next-available-appointment.html
@@ -22,7 +22,7 @@
     <h2 class="heading-medium">Next available appointment:</h2>
 
   {{
-    ui_element_macros.link_appointment({
+    ui_element_macros.appointment_summary({
       link_url: 'change-appointment',
       appointment_date: 'Monday 28th January 2016',
       appointment_time: '11:00',

--- a/app/views/includes/ui_element_macros.html
+++ b/app/views/includes/ui_element_macros.html
@@ -1,13 +1,21 @@
 <!-- Appointment link block -->
-{% macro link_appointment(i) %}
-  <a href="{{ i.link_url }}" class="link-appointment {{ i.modifier_css_classes }}">
-    <h3 class="heading-medium">{{ i.appointment_date }} at {{ i.appointment_time }}</h3>
-    <img src="{{ i.avatar_img_path }}" class="link-appointment__avatar">
-    <div class="link-appointment__info">
-      <div>{{ i.name }}</div>
-      <div class="font-xsmall">{{ i.appointment_type }}</div>
+{% macro appointment_summary(i) %}
+  {% if i.link_url %}
+    <a href="{{ i.link_url }}" class="appointment-summary {{ i.modifier_css_classes }}">
+  {% else %}
+    <div class="appointment-summary {{ i.modifier_css_classes }}">
+  {% endif %}
+      <h3 class="heading-medium">{{ i.appointment_date }} at {{ i.appointment_time }}</h3>
+      <img src="{{ i.avatar_img_path }}" class="appointment-summary__avatar">
+      <div class="appointment-summary__info">
+        <div>{{ i.name }}</div>
+        <div class="font-xsmall">{{ i.appointment_type }}</div>
+      </div>
+  {% if i.link_url %}
+    </a>
+  {% else %}
     </div>
-  </a>
+  {% endif %}
 {% endmacro %}
 
 <!-- Apointment confirmation block -->


### PR DESCRIPTION
New macro allows the appointment summary to be either a `div` or an `a` depending on whether the `link_url` is present.
