### PR TITLE
Add default values for session practice details

### DIFF
--- a/app/views/register-with-a-gp/register-with-signin-confirmed.html
+++ b/app/views/register-with-a-gp/register-with-signin-confirmed.html
@@ -12,8 +12,11 @@
   </h1>
 
   <div class="text">
-    <p>You are now registered with <strong>{{ session.practice.name
-      }}</strong>, {{ session.practice.address }}</p>
+    <p>
+      You are now registered with
+      <strong>{{ session.practice.name | default('Practice Name') }}</strong>,
+      {{ session.practice.address | default('practice address') }}
+    </p>
 
     <p>It may take up to 6 weeks for your medical records to be moved to your
     new practice, but you can start using services right away</p>

--- a/app/views/register-with-a-gp/register-with-signin-details.html
+++ b/app/views/register-with-a-gp/register-with-signin-details.html
@@ -14,8 +14,9 @@
   </h1>
 
   <div class="text">
-    <p>We will send your details to {{ session.practice.name }}. Please check
-    this information is up to date and make any changes needed.</p>
+    <p>We will send your details to
+    {{ session.practice.name | default('Practice Name') }}. Please check this
+    information is up to date and make any changes needed.</p>
   </div>
 
   <form action="" method="get" class="form">

--- a/app/views/register-with-a-gp/register-without-signin-confirmed.html
+++ b/app/views/register-with-a-gp/register-without-signin-confirmed.html
@@ -12,8 +12,11 @@
   </h1>
 
   <div class="text">
-    <p>You are now registered with <strong>{{ session.practice.name
-      }}</strong>, {{ session.practice.address }}</p>
+    <p>
+      You are now registered with
+      <strong>{{ session.practice.name | default('Practice Name') }}</strong>,
+      {{ session.practice.address | default('practice address') }}
+    </p>
 
     <div class="panel-indent">
       <p>The first time you go into your new GP you will need to take proof of


### PR DESCRIPTION
If the pages that pull practice details from the session are accessed directly then the page appears to be missing text.

During normal usage, a user should go through a page that sets the session, so this shouldn't impact them. For cases where we are hitting that page directly, for example to grab a screenshot, it's nice to have some default text.

Eg:
<img width="593" alt="screen shot 2015-09-21 at 16 06 05" src="https://cloud.githubusercontent.com/assets/74812/9995581/b4df921c-607a-11e5-82b5-c98c910efcdd.png">
