### PR TITLE
Empty footer

### DIFF
--- a/app/assets/sass/modules/nhs-template.scss
+++ b/app/assets/sass/modules/nhs-template.scss
@@ -45,3 +45,24 @@
     padding: 15px 30px;
   }
 }
+
+html,
+#footer {
+  background-color: rgba($nhs-black, 0.1);
+}
+
+#footer {
+
+  @extend %contain-floats;
+
+  .footer-wrapper {
+    max-width: 960px;
+  	margin: 0 15px;
+    padding: 0;
+
+    @include media(tablet) {
+      margin: 0 auto;
+      padding: 0 30px;
+    }
+  }
+}

--- a/app/assets_govuk_legacy/stylesheets/govuk-template.css
+++ b/app/assets_govuk_legacy/stylesheets/govuk-template.css
@@ -10,7 +10,7 @@
   src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); }
 
 #global-header .header-wrapper:after, #global-header .header-wrapper .header-global:after, #global-header .header-wrapper .header-global .header-logo:after, #global-header .header-proposition #proposition-link:after,
-#global-header .header-proposition #proposition-links:after, #footer .footer-wrapper:after, #footer .footer-meta:after {
+#global-header .header-proposition #proposition-links:after {
   content: "";
   display: block;
   clear: both; }
@@ -56,8 +56,7 @@ html {
   -webkit-text-size-adjust: 100%;
   /* 1 */
   -ms-text-size-adjust: 100%;
-  /* 1 */
-  background-color: #dee0e2; }
+  /* 1 */ }
 
 /*
   Force the scrollbar to always display in IE10/11
@@ -220,113 +219,3 @@ textarea:focus,
 select:focus,
 button:focus {
   outline: 3px solid #ffbf47; }
-
-/* Global footer */
-#footer {
-  background-color: #dee0e2; }
-  #footer .footer-wrapper {
-    margin: 0 auto;
-    width: auto;
-    max-width: 1020px;
-    padding-top: 20px;
-    background-color: #dee0e2;
-    margin: 0 auto; }
-    @media (min-width: 641px) {
-      #footer .footer-wrapper {
-        padding-top: 60px; } }
-  #footer a {
-    color: #454a4c; }
-    #footer a:hover {
-      color: #171819; }
-  #footer h2 {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 24px;
-    line-height: 1.25;
-    font-weight: 400;
-    text-transform: none;
-    font-weight: bold;
-    color: #171819;
-    margin: 0; }
-    @media (max-width: 640px) {
-      #footer h2 {
-        font-size: 18px;
-        line-height: 1.2; } }
-    #footer h2 a {
-      color: inherit; }
-  #footer .footer-meta {
-    padding-left: 15px;
-    padding-right: 15px;
-    padding-bottom: 60px;
-    clear: both;
-    font-size: 0;
-    color: #454a4c; }
-    @media (min-width: 641px) {
-      #footer .footer-meta {
-        padding-left: 30px;
-        padding-right: 30px; } }
-    #footer .footer-meta .footer-meta-inner {
-      display: inline-block;
-      vertical-align: bottom;
-      width: 100%; }
-      @media (min-width: 641px) {
-        #footer .footer-meta .footer-meta-inner {
-          width: 75%; } }
-      #footer .footer-meta .footer-meta-inner ul {
-        font-family: "nta", Arial, sans-serif;
-        font-size: 16px;
-        line-height: 1.5;
-        font-weight: 400;
-        text-transform: none;
-        display: inline-block;
-        list-style: none;
-        margin: 0 0 1.5em 0;
-        padding: 0; }
-        @media (max-width: 640px) {
-          #footer .footer-meta .footer-meta-inner ul {
-            font-size: 14px;
-            line-height: 1.5; } }
-        @media (min-width: 641px) {
-          #footer .footer-meta .footer-meta-inner ul {
-            margin: 0 0 1em 0; } }
-        #footer .footer-meta .footer-meta-inner ul li {
-          display: inline-block;
-          margin: 0 15px 0 0; }
-      #footer .footer-meta .footer-meta-inner .open-government-licence {
-        clear: left;
-        position: relative; }
-        @media (min-width: 641px) {
-          #footer .footer-meta .footer-meta-inner .open-government-licence {
-            padding-left: 53px; } }
-        #footer .footer-meta .footer-meta-inner .open-government-licence .logo {
-          margin-bottom: 1em;
-          padding-top: 0; }
-          @media (min-width: 641px) {
-            #footer .footer-meta .footer-meta-inner .open-government-licence .logo {
-              position: absolute;
-              left: 0;
-              top: 0;
-              width: 41px;
-              height: 100%; } }
-          #footer .footer-meta .footer-meta-inner .open-government-licence .logo a {
-            display: block;
-            width: 41px;
-            height: 17px;
-            overflow: hidden;
-            text-indent: -999em;
-            background: url(images/open-government-licence.png?0.12.0) 0 0 no-repeat; }
-            @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 20 / 10), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
-              #footer .footer-meta .footer-meta-inner .open-government-licence .logo a {
-                background-image: url(images/open-government-licence_2x.png?0.12.0);
-                background-size: 41px 17px; } }
-        #footer .footer-meta .footer-meta-inner .open-government-licence p {
-          font-family: "nta", Arial, sans-serif;
-          font-size: 16px;
-          line-height: 1.25;
-          font-weight: 400;
-          text-transform: none;
-          margin: 0;
-          padding-top: 0.1em; }
-          @media (max-width: 640px) {
-            #footer .footer-meta .footer-meta-inner .open-government-licence p {
-              font-size: 14px;
-              line-height: 1.14286; } }

--- a/app/views/includes/nhs.uk/footer.html
+++ b/app/views/includes/nhs.uk/footer.html
@@ -1,0 +1,18 @@
+<footer class="group js-footer" id="footer" role="contentinfo">
+
+  <div class="footer-wrapper">
+    {% block footerTop %}{% endblock %}
+
+    <div class="footer-meta">
+      <div class="footer-meta-inner">
+        {% block footerSupportLinks %}{% endblock %}
+
+        <div class="open-government-licence">
+          <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+          <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</footer>

--- a/app/views/includes/nhs.uk/footer.html
+++ b/app/views/includes/nhs.uk/footer.html
@@ -1,18 +1,7 @@
-<footer class="group js-footer" id="footer" role="contentinfo">
+<footer id="footer" role="contentinfo">
 
   <div class="footer-wrapper">
-    {% block footerTop %}{% endblock %}
-
-    <div class="footer-meta">
-      <div class="footer-meta-inner">
-        {% block footerSupportLinks %}{% endblock %}
-
-        <div class="open-government-licence">
-          <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
-          <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
-        </div>
-      </div>
-
-    </div>
+    
   </div>
+
 </footer>

--- a/app/views/templates/nhs_template.html
+++ b/app/views/templates/nhs_template.html
@@ -39,26 +39,7 @@
 
     {% block content %}{% endblock %}
 
-    <footer class="group js-footer" id="footer" role="contentinfo">
-
-      <div class="footer-wrapper">
-        {% block footerTop %}{% endblock %}
-
-        <div class="footer-meta">
-          <div class="footer-meta-inner">
-            {% block footerSupportLinks %}{% endblock %}
-
-            <div class="open-government-licence">
-              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
-              <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
-            </div>
-          </div>
-
-        </div>
-      </div>
-    </footer>
-
-    <!--end footer-->
+    {% include "includes/nhs.uk/footer.html" %}
 
     <div id="global-app-error" class="app-error hidden"></div>
 


### PR DESCRIPTION
Empty the content from the footer until we have an idea of what content should be there.
Remove css references from the legacy govuk template css.
Footer is now an include (because I think there's a need for an nhs_template for content, as well as a stripped back one for "transactions")
