### PR TITLE
Use "GP practice" rather than "GP" wording

### DIFF
--- a/app/views/includes/service-headers/register-with-a-gp.html
+++ b/app/views/includes/service-headers/register-with-a-gp.html
@@ -1,5 +1,5 @@
 <div class="service-header">
 	<div class="service-name font-small">
-		Register with a GP
+		Register with a GP practice
 	</div>
 </div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -16,7 +16,7 @@
   <h2 class="heading-large">Prototypes</h2>
 
   <ul>
-    <li><a href="/register-with-a-gp/">Register with a GP</a></li>
+    <li><a href="/register-with-a-gp/">Register with a GP practice</a></li>
     <li><a href="/book-an-appointment/">Book an Appointment</a></li>
     <li><a href="/change-or-cancel-an-appointment/">Change or Cancel an Appointment</a></li>
     <li><a href="/booking-with-context/">Booking with Context</a></li>

--- a/app/views/register-with-a-gp/find-a-gp.html
+++ b/app/views/register-with-a-gp/find-a-gp.html
@@ -10,7 +10,7 @@
 <main id="content" role="main">
 
   <h1 class="heading-xlarge">
-    Find a GP
+    Find a GP practice
   </h1>
 
   <div class="text">
@@ -24,7 +24,7 @@
       }}
 
       <div class="form-group">
-        <a class="button" href="suggested-gps">Find a GP</a>
+        <a class="button" href="suggested-gps">Find a GP practice</a>
       </div>
     </form>
   </div>

--- a/app/views/register-with-a-gp/register-without-signin-confirmed.html
+++ b/app/views/register-with-a-gp/register-without-signin-confirmed.html
@@ -19,7 +19,7 @@
     </p>
 
     <div class="panel-indent">
-      <p>The first time you go into your new GP you will need to take proof of
+      <p>The first time you go into your new GP practice you will need to take proof of
       your identity:</p>
 
       <ul class="list-bullet">

--- a/app/views/register-with-a-gp/start.html
+++ b/app/views/register-with-a-gp/start.html
@@ -4,7 +4,7 @@
 
 <main id="content" role="main">
 
-  <h1 class="heading-xlarge">Register with a GP</h1>
+  <h1 class="heading-xlarge">Register with a GP practice</h1>
 
   <div class="text">
     <p>
@@ -12,9 +12,9 @@
     </p>
 
     <ul class="list-bullet">
-      <li>register with a GP for the first time</li>
-      <li>register with a new GP after a house move or other reason</li>
-      <li>register someone else or a dependant with a new GP</li>
+      <li>register with a GP practice for the first time</li>
+      <li>register with a new GP practice after a house move or other reason</li>
+      <li>register someone else or a dependant with a new GP practice</li>
     </ul>
 
     <p>

--- a/app/views/register-with-a-gp/suggested-gps.html
+++ b/app/views/register-with-a-gp/suggested-gps.html
@@ -9,12 +9,12 @@
 <main id="content" role="main">
 
   <h1 class="heading-xlarge">
-    Suggested GPs
+    Suggested GP practices
   </h1>
 
   <div class="text">
 
-    <p class="lede">Your <b>3 nearest GPs</b> for NW13 9HL are:</p>
+    <p class="lede">Your <b>3 nearest GP practices</b> for NW13 9HL are:</p>
 
     <ol>
       <li class="expand-bottom">
@@ -54,7 +54,7 @@
 
         <p class="expand-top-half">
           <b>82%</b>
-          of patients recommend this GP
+          of patients recommend this GP practice
         </p>
 
       </li>
@@ -83,7 +83,7 @@
 
         <p class="expand-top-half">
           <b>89%</b>
-          of patients recommend this GP
+          of patients recommend this GP practice
         </p>
 
       </li>
@@ -119,7 +119,7 @@
         </table>
 
         <p class="expand-top-half">
-          <b>74%</b> of patients recommend this GP
+          <b>74%</b> of patients recommend this GP practice
         </p>
 
       </li>
@@ -128,7 +128,7 @@
     <hr style="height: 3px;">
 
     <p>
-      <a href="#"><b>See more GPs near me</b></a>
+      <a href="#"><b>See more GP practices near me</b></a>
     </p>
     <p class="font-xsmall">
       or <a href="find-a-gp">search again</a>


### PR DESCRIPTION
Although we casually refer to a GP practice as just a "GP", it's inaccurate.
It can be confusing as people used to register with a named GP but generally
now register with a GP practice.
