### PR TITLE
Advertise "Appointment hours"

### DIFF
--- a/app/views/register-with-a-gp/suggested-gps.html
+++ b/app/views/register-with-a-gp/suggested-gps.html
@@ -32,7 +32,7 @@
           </span>
         </p>
 
-        <h3 class="font-small">Appointments available:</h3>
+        <h3 class="font-small">Appointment hours:</h3>
         <table>
           <tr>
             <td>Monday</td>
@@ -73,7 +73,7 @@
           </span>
         </p>
 
-        <h3 class="font-small">Appointments available:</h3>
+        <h3 class="font-small">Appointment hours:</h3>
         <table>
           <tr>
             <td>Monday to Friday</td>
@@ -102,7 +102,7 @@
           </span>
         </p>
 
-        <h3 class="font-small">Appointments available:</h3>
+        <h3 class="font-small">Appointment hours:</h3>
         <table>
           <tr>
             <td>Monday and Tuesday</td>


### PR DESCRIPTION
...rather than "Appointments available"

In user testing, one user thought it would be possible to actually book
one of these appointments, rather than it just being information about
opening/appointment hours.

I appreciate that this doesn't fix the problem of the table being a bit baffling for one user, but it's probably an improvement anyhow.

![image](https://cloud.githubusercontent.com/assets/254290/10098148/c98933ae-6376-11e5-801a-a827e1fbf445.png)
