### PR TITLE
Add appointment hours to practice details pages

### DIFF
--- a/app/views/register-with-a-gp/lakeside-surgery.html
+++ b/app/views/register-with-a-gp/lakeside-surgery.html
@@ -147,6 +147,26 @@
     </div>
     <div class="column-half">
 
+      <h2 class="heading-large">Appointment hours</h3>
+      <table>
+        <tr>
+          <td>Monday</td>
+          <td>9am &ndash; 4.50pm</td>
+        </tr>
+        <tr>
+          <td>Tuesday</td>
+          <td>7.30am &ndash; 7.20pm</td>
+        </tr>
+        <tr>
+          <td>Wednesday and Thursday</td>
+          <td>9am &ndash; 4.50pm</td>
+        </tr>
+        <tr>
+          <td>Friday</td>
+          <td>7.30am &ndash; 7.20pm</td>
+        </tr>
+      </table>
+
       <h2 class="heading-large">Services</h2>
       <ul class="list-bullet">
         <li>Travel vaccinations</li>

--- a/app/views/register-with-a-gp/shrewsbottom-surgery.html
+++ b/app/views/register-with-a-gp/shrewsbottom-surgery.html
@@ -146,6 +146,14 @@
     </div>
     <div class="column-half">
 
+      <h2 class="heading-large">Appointment hours:</h3>
+      <table>
+        <tr>
+          <td>Monday to Friday</td>
+          <td>9am &ndash; 5pm</td>
+        </tr>
+      </table>
+
       <h2 class="heading-large">Services</h2>
       <ul class="list-bullet">
         <li>Travel vaccinations</li>

--- a/app/views/register-with-a-gp/victoria-medical-centre.html
+++ b/app/views/register-with-a-gp/victoria-medical-centre.html
@@ -147,6 +147,22 @@
     </div>
     <div class="column-half">
 
+      <h2 class="heading-large">Appointment hours:</h3>
+      <table>
+        <tr>
+          <td>Monday and Tuesday</td>
+          <td>9am &ndash; 5pm</td>
+        <tr>
+        </tr>
+          <td>Wednesday</td>
+          <td>9am &ndash; 9pm</td>
+        <tr>
+        </tr>
+          <td>Thursday and Friday</td>
+          <td>9am &ndash; 5pm</td>
+        </tr>
+      </table>
+
       <h2 class="heading-large">Services</h2>
       <ul class="list-bullet">
         <li>Travel vaccinations</li>


### PR DESCRIPTION
I've tried putting this in the grid layout just above "Services", whaddya reckon?

![image](https://cloud.githubusercontent.com/assets/254290/10100339/f42ed1ba-6388-11e5-9798-2cf7c9bac1b0.png)
