### PR TITLE
Redirect to absolute paths from index pages

### DIFF
--- a/app/views/book-an-appointment/index.html
+++ b/app/views/book-an-appointment/index.html
@@ -1,3 +1,3 @@
 <html>
-<meta http-equiv="refresh" content="0; url=start">
+<meta http-equiv="refresh" content="0; url=/book-an-appointment/start">
 </html>

--- a/app/views/booking-with-context/index.html
+++ b/app/views/booking-with-context/index.html
@@ -1,3 +1,3 @@
 <html>
-<meta http-equiv="refresh" content="0; url=going-for-regular-diabetes-check-ups">
+<meta http-equiv="refresh" content="0; url=/booking-with-context/going-for-regular-diabetes-check-ups">
 </html>

--- a/app/views/change-or-cancel-an-appointment/index.html
+++ b/app/views/change-or-cancel-an-appointment/index.html
@@ -1,3 +1,3 @@
 <html>
-<meta http-equiv="refresh" content="0; url=start">
+<meta http-equiv="refresh" content="0; url=/change-or-cancel-an-appointment/start">
 </html>


### PR DESCRIPTION
Using a relative URL redirects to the wrong place if the page is requested without a trailing slash.
