### PR TITLE
Make all appointments bookable

### DIFF
--- a/app/views/book-an-appointment/all-appointments.html
+++ b/app/views/book-an-appointment/all-appointments.html
@@ -20,7 +20,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '10:20',
       avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
@@ -33,7 +33,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Wednesday 27th January 2016',
       appointment_time: '13:10',
       avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
@@ -47,7 +47,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Thursday 28th January 2016',
       appointment_time: '11:30',
       avatar_img_path: '/public/images/icon-avatar-mike-johnson.png',
@@ -59,7 +59,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Thursday 28th January 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-jonathon-hope.png',
@@ -74,7 +74,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Friday 29th January 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -86,7 +86,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Friday 29th January 2016',
       appointment_time: '14:40',
       avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
@@ -100,7 +100,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 2nd February 2016',
       appointment_time: '11:30',
       avatar_img_path: '/public/images/icon-avatar-mike-johnson.png',
@@ -112,7 +112,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 2nd February 2016',
       appointment_time: '13:10',
       avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
@@ -124,7 +124,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 2nd February 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-jonathon-hope.png',
@@ -136,7 +136,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -161,7 +161,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Wednesday 3rd February 2016',
       appointment_time: '11:30',
       avatar_img_path: '/public/images/icon-avatar-mike-johnson.png',
@@ -173,7 +173,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Wednesday 3rd February 2016',
       appointment_time: '13:10',
       avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
@@ -185,7 +185,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Wednesday 3rd February 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-jonathon-hope.png',
@@ -197,7 +197,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '15:10',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',

--- a/app/views/book-an-appointment/appointments-with-practitioner.html
+++ b/app/views/book-an-appointment/appointments-with-practitioner.html
@@ -20,7 +20,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '10:20',
       avatar_img_path: practitioner.avatar,
@@ -32,7 +32,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Thursday 28th January 2016',
       appointment_time: '11:30',
       avatar_img_path: practitioner.avatar,

--- a/app/views/book-an-appointment/next-appointment-early-morning.html
+++ b/app/views/book-an-appointment/next-appointment-early-morning.html
@@ -26,7 +26,7 @@
 
   {{
     ui_element_macros.appointment_summary({
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Friday 29th January 2016',
       appointment_time: '08:30',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -40,7 +40,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -52,7 +52,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Thursday 28th January 2016',
       appointment_time: '11:30',
       avatar_img_path: '/public/images/icon-avatar-mike-johnson.png',

--- a/app/views/book-an-appointment/next-appointment-with-woman-early-morning.html
+++ b/app/views/book-an-appointment/next-appointment-with-woman-early-morning.html
@@ -40,7 +40,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -52,7 +52,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Thursday 28th January 2016',
       appointment_time: '11:30',
       avatar_img_path: '/public/images/icon-avatar-mike-johnson.png',

--- a/app/views/book-an-appointment/next-appointment-with-woman.html
+++ b/app/views/book-an-appointment/next-appointment-with-woman.html
@@ -40,7 +40,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -52,7 +52,7 @@
   {{
     ui_element_macros.appointment_summary({
       modifier_css_classes: 'appointment-summary--secondary',
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Thursday 28th January 2016',
       appointment_time: '11:30',
       avatar_img_path: '/public/images/icon-avatar-mike-johnson.png',

--- a/app/views/book-an-appointment/next-available-appointment.html
+++ b/app/views/book-an-appointment/next-available-appointment.html
@@ -26,7 +26,7 @@
 
   {{
     ui_element_macros.appointment_summary({
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Tuesday 26th January 2016',
       appointment_time: '16:10',
       avatar_img_path: '/public/images/icon-avatar-malcolm-branch.png',
@@ -37,7 +37,7 @@
 
   {{
     ui_element_macros.appointment_summary({
-      link_url: '#',
+      link_url: 'appointment-confirmed',
       appointment_date: 'Thursday 28th January 2016',
       appointment_time: '11:30',
       avatar_img_path: '/public/images/icon-avatar-mike-johnson.png',


### PR DESCRIPTION
When users try to pick an appointment that isn't linked up to the confirmation page they just stay on the current page. Even though the confirmation page won't have the right details, it would be better to make that journey join up to see how they'll use it.
