### PR TITLE
One day per row for appointment hours

### DIFF
--- a/app/views/register-with-a-gp/suggested-gps.html
+++ b/app/views/register-with-a-gp/suggested-gps.html
@@ -43,7 +43,11 @@
             <td>7.30am &ndash; 7.20pm</td>
           </tr>
           <tr>
-            <td>Wednesday and Thursday</td>
+            <td>Wednesday</td>
+            <td>9am &ndash; 4.50pm</td>
+          </tr>
+          <tr>
+            <td>Thursday</td>
             <td>9am &ndash; 4.50pm</td>
           </tr>
           <tr>
@@ -105,7 +109,11 @@
         <h3 class="font-small">Appointment hours:</h3>
         <table>
           <tr>
-            <td>Monday and Tuesday</td>
+            <td>Monday</td>
+            <td>9am &ndash; 5pm</td>
+          <tr>
+          <tr>
+            <td>Tuesday</td>
             <td>9am &ndash; 5pm</td>
           <tr>
           </tr>
@@ -113,7 +121,11 @@
             <td>9am &ndash; 9pm</td>
           <tr>
           </tr>
-            <td>Thursday and Friday</td>
+            <td>Thursday</td>
+            <td>9am &ndash; 5pm</td>
+          </tr>
+          </tr>
+            <td>Friday</td>
             <td>9am &ndash; 5pm</td>
           </tr>
         </table>


### PR DESCRIPTION
Where the appointment times differ through the week, give each day its own line, even where opening times are the same as the previous day. This is a pretty small incremental improvement, and may not be enough to avoid needing an overhaul.

Before:
<img width="312" alt="screen shot 2015-09-25 at 15 26 25" src="https://cloud.githubusercontent.com/assets/74812/10103055/dbc79146-6399-11e5-9187-97577710603b.png">

After:
<img width="313" alt="screen shot 2015-09-25 at 15 23 51" src="https://cloud.githubusercontent.com/assets/74812/10103057/e1a294b2-6399-11e5-84dd-48ef0f624326.png">

For Shrewsbottom Surgery, which has the same opening hours all week, leave it as a single entry.

<img width="306" alt="screen shot 2015-09-25 at 15 24 01" src="https://cloud.githubusercontent.com/assets/74812/10103062/e76d9298-6399-11e5-8b1a-ecd0eca109d8.png">
