### PR TITLE
Put meaningful content on the confirmation page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -160,9 +160,12 @@ function appointment_details_for_service(slug) {
         name: 'Diabetes foot check',
         triage_hint: 'In your GP practice, diabetes foot checks are carried ' +
                      'out by a practice nurse.',
-        confirmation_hint: "You'll need to remove your shoes and socks " +
-                           "at your appointment so make sure you wear " +
-                           "comfortable footwear.",
+        confirmation_hint: "<p>People with diabetes have a much greater risk of " +
+          "developing problems with their feet. It is therefore important to " +
+          "have your feet examined regularly or if you have cuts or bruises.</p>" +
+          "<p>You will be asked to remove " +
+          "any footwear and the healthcare professional will examine your feet.</p>" +
+          "<p>The charity Diabetes UK has information on <a href='https://www.diabetes.org.uk/Documents/Guide%20to%20diabetes/monitoring/What-to-expect-at-annual-foot-check.pdf'>what to expect at your annual foot check.</a>",
         appointment: {
           link_url: 'appointment-confirmed?service=' + slug,
           appointment_date: 'Tuesday 26th January 2016',

--- a/app/routes.js
+++ b/app/routes.js
@@ -184,8 +184,11 @@ function appointment_details_for_service(slug) {
         triage_hint: 'For your GP practice, diabetic eye screening is ' +
                      'carried out at: ' +
                      '<br>The Royal Hospital<br>34 Queen\'s Avenue<br>SW14 4JR',
-        confirmation_hint: 'Please bring along any glasses or contact lenses ' +
-                           'if you wear them.',
+        confirmation_hint: '<p>People with diabetes are at risk of eye damage from diabetic retinopathy. Screening is a way of detecting the condition early before you notice any changes to your vision.</p>' +
+          '<p>The check takes about half an hour and involves examining the back of the eyes and taking photographs of the retina.</p>' +
+          '<p>If you wear glasses, bring these with you to the appointment.</p>' +
+          '<p>It is also advisable to bring sunglasses with you to help on the way home. When your pupils expand, lights will become brighter.</p>' +
+          '<p>The charity Diabetes UK have further <a href="http://www.diabetes.co.uk/diabetes-complications/retinopathy-screening.html">information about eye screening appointments.</a></p>',
         appointment: {
           link_url: 'appointment-confirmed?service=' + slug,
           appointment_date: 'Tuesday 26th January 2016',

--- a/app/routes.js
+++ b/app/routes.js
@@ -139,8 +139,10 @@ function appointment_details_for_service(slug) {
         name: 'Blood sugar test',
         triage_hint: 'In your GP practice, blood sugar test appointments ' +
                        'are carried out by a practice nurse.',
-        confirmation_hint: "You don't need to do anything special before the " +
-                           "test - just eat and drink as you normally would.",
+        confirmation_hint: "<p>The glycated haemoglobin (HbA1c) test gives your average blood glucose levels over the previous two to three months. The results can indicate whether the measures you're taking to control your diabetes are working.</p>" +
+          "<p>Unlike other tests the HbA1c test can be carried out at any time of day and it doesn't require any special preparation, such as fasting.</p>" +
+          "<p>The test will involve taking a small sample of blood from a vein.</p>",
+
         appointment: {
           link_url: 'appointment-confirmed?service=' + slug,
           appointment_date: 'Tuesday 26th January 2016',

--- a/app/routes.js
+++ b/app/routes.js
@@ -206,8 +206,9 @@ function appointment_details_for_service(slug) {
         name: 'Diabetes annual review',
         triage_hint: 'In your GP practice, diabetes annual reviews are ' +
                      'carried out by a nurse practitioner.',
-        confirmation_hint: "Remember to bring along any records or information " +
-                           "such as blood glucose levels that you want to discuss.",
+        confirmation_hint: '<p>Your diabetic review will allow your doctors to monitor your health and assess aspects such as your long term blood glucose control, cholesterol levels and blood pressure.</p>' +
+          '<p>Because the review covers a lot of different things, it can be useful to bring a notebook and pen.</p>' +
+          '<p>The charity Diabetes UK have <a href="http://www.diabetes.co.uk/nhs/diabetes-annual-care-review.html">information about the diabetes annual review.</a></p>',
         appointment: {
           link_url: 'appointment-confirmed?service=' + slug,
           appointment_date: 'Monday 25th January 2016',

--- a/app/views/booking-with-context/appointment-confirmed.html
+++ b/app/views/booking-with-context/appointment-confirmed.html
@@ -33,6 +33,10 @@
 
   <hr>
 
+  <p>
+    A copy of this page has been sent to your email address.
+  </p>
+
   <div class="font-xsmall">
     <p>
       We will send you SMS reminders of your appointment. <a href="#">Change reminders</a>

--- a/app/views/booking-with-context/appointment-confirmed.html
+++ b/app/views/booking-with-context/appointment-confirmed.html
@@ -13,12 +13,6 @@
     Appointment confirmed
   </h1>
 
-  <div class="panel-indent text">
-    <p>
-    {{ service_context.confirmation_hint }}
-    </p>
-  </div>
-
   {{ ui_element_macros.appointment_confirmation(service_context.appointment) }}
 
   <p>
@@ -39,12 +33,22 @@
 
   <hr>
 
-
   <div class="font-xsmall">
     <p>
       We will send you SMS reminders of your appointment. <a href="#">Change reminders</a>
     </p>
   </div>
+
+  <h2 class="heading-large">
+      About your {{ service_context.name|lower }}
+  </h2>
+
+  <div class="text">
+    <p>
+    {{ service_context.confirmation_hint }}
+    </p>
+  </div>
+
 
 </main>
 {% endblock %}

--- a/app/views/booking-with-context/appointment-confirmed.html
+++ b/app/views/booking-with-context/appointment-confirmed.html
@@ -45,7 +45,7 @@
 
   <div class="text">
     <p>
-    {{ service_context.confirmation_hint }}
+    {{ service_context.confirmation_hint|safe }}
     </p>
   </div>
 


### PR DESCRIPTION
I don't think this is a bad start, but it's definitely up for debate how much
we should be sending people out to other sites and providing information ourselves.

These text blocks became quite big, I suspect maybe it would be better to have
sections like:
- why the appointment is important
- any preparation required
- what will actually happen at the appointment

I think we need an intervention from the content team :)
