### PR TITLE
Show waiting time in days, not as % happiness

### DIFF
--- a/app/views/register-with-a-gp/lakeside-surgery.html
+++ b/app/views/register-with-a-gp/lakeside-surgery.html
@@ -54,8 +54,8 @@
     </div>
     <div class="column-third">
       <p>
-        <span class="bold-large">65%</span><br>
-        are happy with waiting times
+        <span class="bold-large">8 days</span><br>
+        average wait time for routine appointments
       </p>
     </div>
   </div>

--- a/app/views/register-with-a-gp/shrewsbottom-surgery.html
+++ b/app/views/register-with-a-gp/shrewsbottom-surgery.html
@@ -53,8 +53,8 @@
     </div>
     <div class="column-third">
       <p>
-        <span class="bold-large">65%</span><br>
-        are happy with waiting times
+        <span class="bold-large">5 days</span><br>
+        average wait time for routine appointments
       </p>
     </div>
   </div>

--- a/app/views/register-with-a-gp/victoria-medical-centre.html
+++ b/app/views/register-with-a-gp/victoria-medical-centre.html
@@ -54,8 +54,8 @@
     </div>
     <div class="column-third">
       <p>
-        <span class="bold-large">65%</span><br>
-        are happy with waiting times
+        <span class="bold-large">13 days</span><br>
+        average wait time for routine appointments
       </p>
     </div>
   </div>


### PR DESCRIPTION
We've seen "wait time" be interpreted in multiple ways – is it the amount of time until the next available appointment, or is it how long you have to spend sitting in the waiting room?

Showing it like this should remove that ambiguity, and allow people to provide their own valuation. 8 days for a routine appointment might be good for some people, and awful for others.

Looks like this when skinny:

<img width="320" alt="screen shot 2015-09-28 at 13 22 55" src="https://cloud.githubusercontent.com/assets/74812/10135432/cf47609c-65e5-11e5-8f34-8bb98e19960e.png">

Looks like this when wide:

<img width="961" alt="screen shot 2015-09-28 at 13 22 36" src="https://cloud.githubusercontent.com/assets/74812/10135436/d78cac4e-65e5-11e5-93a5-1e18eeec2514.png">
