### PR TITLE
Show appointment length for some appointments

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -150,6 +150,7 @@ function appointment_details_for_service(slug) {
           avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
           name: 'Nurse Alison Wylde',
           appointment_type: 'Face to face',
+          appointment_length: 5,
           address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ'
         }
 
@@ -173,6 +174,7 @@ function appointment_details_for_service(slug) {
           avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
           name: 'Nurse Alison Wylde',
           appointment_type: 'Face to face',
+          appointment_length: 20,
           address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ'
         }
 
@@ -196,6 +198,7 @@ function appointment_details_for_service(slug) {
           avatar_img_path: '/public/images/icon-avatar-ravi-aggarwal.png',
           name: 'Nurse Ravi Aggarwal',
           appointment_type: 'Face to face',
+          appointment_length: 30,
           address: "The Royal Hospital<br>34 Queen's Avenue<br>London<br>NW13 9HJ"
         }
 
@@ -216,6 +219,7 @@ function appointment_details_for_service(slug) {
           avatar_img_path: '/public/images/icon-avatar-jonathon-hope.png',
           name: 'Nurse Practitioner Jonathon Hope',
           appointment_type: 'Face to face',
+          appointment_length: 25,
           address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ'
         }
 

--- a/app/views/includes/ui_element_macros.html
+++ b/app/views/includes/ui_element_macros.html
@@ -10,6 +10,9 @@
       <div class="appointment-summary__info">
         <div>{{ i.name }}</div>
         <div class="font-xsmall">{{ i.appointment_type }}</div>
+        {% if i.appointment_length %}
+          <div class="font-xsmall">{{ i.appointment_length }} minutes</div>
+        {% endif %}
       </div>
   {% if i.link_url %}
     </a>


### PR DESCRIPTION
For the booking a service appointments, show the length of the appointment. The service may be unfamiliar to people booking, and showing how long it should take may be important for them to choose an appropriate appointment slot.

Skinny view:

<img width="317" alt="screen shot 2015-09-28 at 14 11 18" src="https://cloud.githubusercontent.com/assets/74812/10136199/249ae492-65eb-11e5-9d17-e320e1c21949.png">

Wide view:

<img width="590" alt="screen shot 2015-09-28 at 14 11 05" src="https://cloud.githubusercontent.com/assets/74812/10136206/2981ee1a-65eb-11e5-91cc-5e423bec40b3.png">
