### PR TITLE
Progressively reveal "armed forces" and "abroad"

### DIFF
--- a/app/views/register-with-a-gp/your-existing-gp-details.html
+++ b/app/views/register-with-a-gp/your-existing-gp-details.html
@@ -22,13 +22,13 @@
       <div class="inline-form-groups">
         <div class="form-group">
           <input type="radio" id="current-gp-yes" name="current-gp">
-          <label class="form-control-radio js-toggle" for="current-gp-yes" data-show="#current-gp">
+          <label class="form-control-radio js-toggle" for="current-gp-yes" data-show="#current-gp" data-hide="armed-forces-group">
             Yes
           </label>
         </div>
         <div class="form-group">
           <input type="radio" id="current-gp-no" name="current-gp">
-          <label class="form-control-radio js-toggle" for="current-gp-no" data-hide="#current-gp">
+          <label class="form-control-radio js-toggle" for="current-gp-no" data-hide="#current-gp" data-show="#armed-forces-group">
             No
           </label>
         </div>
@@ -50,79 +50,83 @@
       }}
     </div>
 
-    <fieldset>
-      <legend class="form-label-bold">Have you recently left the armed forces?</legend>
-      <div class="inline-form-groups">
-        <div class="form-group">
-          <input type="radio" id="armed-forces-yes" name="armed-forces">
-          <label class="form-control-radio js-toggle" for="armed-forces-yes" data-show="#armed-forces">
-            Yes
-          </label>
+    <div class="js-hidden" id="armed-forces-group">
+      <fieldset>
+        <legend class="form-label-bold">Have you recently left the armed forces?</legend>
+        <div class="inline-form-groups">
+          <div class="form-group">
+            <input type="radio" id="armed-forces-yes" name="armed-forces">
+            <label class="form-control-radio js-toggle" for="armed-forces-yes" data-show="#armed-forces" data-hide="#abroad-group">
+              Yes
+            </label>
+          </div>
+          <div class="form-group">
+            <input type="radio" id="armed-forces-no" name="armed-forces">
+            <label class="form-control-radio js-toggle" for="armed-forces-no" data-show="#abroad-group" data-hide="#armed-forces">
+              No
+            </label>
+          </div>
         </div>
-        <div class="form-group">
-          <input type="radio" id="armed-forces-no" name="armed-forces">
-          <label class="form-control-radio js-toggle" for="armed-forces-no" data-hide="#armed-forces">
-            No
-          </label>
-        </div>
-      </div>
-    </fieldset>
+      </fieldset>
 
-    <div class="js-hidden panel-indent" id="armed-forces">
-      <div class="form-group">
-        <label class="form-label-bold" for="service-number">
-          Your service or personnel number
-        </label>
-        <!-- 8 digits -->
-        <input type="text" id="service-number" class="form-control form-control-1-4" value="">
+      <div class="js-hidden panel-indent" id="armed-forces">
+        <div class="form-group">
+          <label class="form-label-bold" for="service-number">
+            Your service or personnel number
+          </label>
+          <!-- 8 digits -->
+          <input type="text" id="service-number" class="form-control form-control-1-4" value="">
+        </div>
+        {{
+          form_macros.date_field({
+            label: 'Enlistment date',
+            hint_date: '31 7 1994',
+            id_prefix: 'enlistment-'
+          })
+        }}
+        {{
+          form_macros.address_fields({
+            id: 'address-2',
+            label: 'Your home address when you enlisted'
+          })
+        }}
       </div>
-      {{
-        form_macros.date_field({
-          label: 'Enlistment date',
-          hint_date: '31 7 1994',
-          id_prefix: 'enlistment-'
-        })
-      }}
-      {{
-        form_macros.address_fields({
-          id: 'address-2',
-          label: 'Your home address when you enlisted'
-        })
-      }}
     </div>
 
-    <fieldset>
-      <legend class="form-label-bold">Are you moving to the UK from abroad?</legend>
-      <div class="inline-form-groups">
-        <div class="form-group">
-          <input type="radio" id="abroad-yes" name="abroad">
-          <label class="form-control-radio js-toggle" for="abroad-yes" data-show="#abroad">
-            Yes
-          </label>
+    <div class="js-hidden" id="abroad-group">
+      <fieldset>
+        <legend class="form-label-bold">Are you moving to the UK from abroad?</legend>
+        <div class="inline-form-groups">
+          <div class="form-group">
+            <input type="radio" id="abroad-yes" name="abroad">
+            <label class="form-control-radio js-toggle" for="abroad-yes" data-show="#abroad">
+              Yes
+            </label>
+          </div>
+          <div class="form-group">
+            <input type="radio" id="abroad-no" name="abroad">
+            <label class="form-control-radio js-toggle" for="abroad-no" data-hide="#abroad">
+              No
+            </label>
+          </div>
         </div>
-        <div class="form-group">
-          <input type="radio" id="abroad-no" name="abroad">
-          <label class="form-control-radio js-toggle" for="abroad-no" data-hide="#abroad">
-            No
-          </label>
-        </div>
-      </div>
-    </fieldset>
+      </fieldset>
 
-    <div class="js-hidden panel-indent" id="abroad">
-      {{
-        form_macros.date_field({
-          label: 'The date you left the UK',
-          hint_date: '31 7 1994',
-          id_prefix: 'left-uk-'
-        })
-      }}
-      {{
-        form_macros.address_fields({
-          id: 'address-3',
-          label: 'Your address when you first registered with A GP'
-        })
-      }}
+      <div class="js-hidden panel-indent" id="abroad">
+        {{
+          form_macros.date_field({
+            label: 'The date you left the UK',
+            hint_date: '31 7 1994',
+            id_prefix: 'left-uk-'
+          })
+        }}
+        {{
+          form_macros.address_fields({
+            id: 'address-3',
+            label: 'Your address when you first registered with A GP'
+          })
+        }}
+      </div>
     </div>
 
     <div class="form-group expand-top">


### PR DESCRIPTION
Don't show "Have you recently left the armed forces?" upfront - only do
this if they are _not_ currently registered with a GP practice.

![image](https://cloud.githubusercontent.com/assets/254290/10540644/ba28f052-7401-11e5-86b0-10b3d8520020.png)

Don't show "Are you moving to the UK from abroad?" until they say "no"
to having left armed forces.

![image](https://cloud.githubusercontent.com/assets/254290/10540648/c421778c-7401-11e5-98ca-fa7507d99966.png)

I'm making the assumption here that it's not possible to be registered
with a GP **and** recently have left the armed forces. Ditto with having
moved back from abroad.
