### PR TITLE
Swap out the 30em measure for the 'measure' mixin

### DIFF
--- a/app/assets/sass/typography/_typography.scss
+++ b/app/assets/sass/typography/_typography.scss
@@ -33,7 +33,8 @@ body {
 // Set a max-width for text blocks
 // Less than 75 characters per line of text
 .text {
-  max-width: 30em;
+//  max-width: 30em;
+@include measure(all);
 }
 
 .text-secondary {


### PR DESCRIPTION
Type measure now sits at 50rem for smaller screens and 45.83rem for larger ones.

Applies to elements with class of `.text`
