### PR TITLE
Adding a footer to prototypes ...

### DIFF
--- a/app/assets/sass/modules/nhs-template.scss
+++ b/app/assets/sass/modules/nhs-template.scss
@@ -6,6 +6,7 @@ body {
 
 #global-header {
   background-color: $nhs-blue;
+  border-bottom: 6px solid #e5f0f9;
 
   @extend %contain-floats;
 
@@ -130,22 +131,29 @@ body {
 .service-header .service-name {
   max-width: 960px;
 	margin: 0 15px;
-  padding: 8px 0;
+  padding: 2px 0 8px 0;
 
   @include media(tablet) {
     margin: 0 auto;
-    padding: 15px 30px;
+    padding: 9px 30px 15px 30px;
   }
 }
 
-//html,
+html,
 #footer {
-  background-color: rgba($nhs-black, 0.1);
+  background-color: $nhs-black;
 }
 
 #footer {
+  color: #d9dbdd;
+  padding: 2rem 0;
+  border-top: 6px solid $nhs-grey-1;
 
   @extend %contain-floats;
+
+  a {
+    color: #d9dbdd;
+  }
 
   .footer-wrapper {
     max-width: 960px;

--- a/app/views/includes/nhs.uk/footer.html
+++ b/app/views/includes/nhs.uk/footer.html
@@ -1,7 +1,18 @@
 <footer id="footer" role="contentinfo">
 
   <div class="footer-wrapper">
-    
+
+    <div class="text">
+
+      <p>
+        <small>
+          &copy; Crown copyright<br>
+          Content available under <a href="#">Open Government Licence v3.0</a>, except where otherwise stated.
+        </small>
+      </p>
+
+    </div>
+
   </div>
 
 </footer>

--- a/app/views/includes/nhs.uk/footer.html
+++ b/app/views/includes/nhs.uk/footer.html
@@ -7,7 +7,7 @@
       <p>
         <small>
           &copy; Crown copyright<br>
-          Content available under <a href="#">Open Government Licence v3.0</a>, except where otherwise stated.
+          Content available under <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a>, except where otherwise stated.
         </small>
       </p>
 


### PR DESCRIPTION
- Anchor the page a bit visually
- Provide a copyright message
- Also add a small border to the header to smooth into transaction titles (i.e. register with a GP)

<img width="306" alt="screen shot 2015-10-19 at 11 28 54" src="https://cloud.githubusercontent.com/assets/1913757/10575484/a7018318-7654-11e5-8e90-4285b887339b.png">
<img width="224" alt="screen shot 2015-10-19 at 11 29 03" src="https://cloud.githubusercontent.com/assets/1913757/10575483/a70158c0-7654-11e5-9977-85c07af8baa0.png">
