### PR TITLE
Add simple travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "0.10"
+before_script:
+  - npm install
+  - npm install -g grunt-cli
+script:
+  - ./node_modules/grunt-cli/bin/grunt --gruntfile Gruntfile.js generate-assets


### PR DESCRIPTION
For now, just test that we can generate assets successfully.

I tried modifying `server.js` to exit (successfully) right before doing
`app.listen` but this didn't actually replicate the app starting up. When I
faked an error (broke a `db/*.json` file) the tests still passed; so those must
be loading within the `app.listen` call.
