### PR TITLE
Sorting out outline gaps in Safari (switched to border and box-shadow)

### DIFF
--- a/app/assets/sass/elements/_forms.scss
+++ b/app/assets/sass/elements/_forms.scss
@@ -18,7 +18,6 @@ fieldset {
 .form-item-wrapper {
   padding: 1rem 0 0 0;
   @extend %contain-floats;
-  //outline: 1px dotted red;
 }
 
 // Form group is used to wrap label and input pairs
@@ -84,8 +83,10 @@ fieldset {
   line-height: 4rem;
   padding: 0 1rem;
   background-color: $white;
-  outline: 1px solid $nhs-black;
-  border: 2px solid $nhs-grey-2;
+  border: 1px solid $nhs-black;
+  -webkit-box-shadow: inset 0px 0px 0px 2px $nhs-grey-2;
+  -moz-box-shadow: inset 0px 0px 0px 2px $nhs-grey-2;
+  box-shadow: inset 0px 0px 0px 2px $nhs-grey-2;
 
   // Disable webkit appearance and remove rounded corners
   -webkit-appearance: none;
@@ -93,6 +94,12 @@ fieldset {
 
   @include media(tablet) {
     width: 50%;
+  }
+
+  &:focus {
+    -webkit-box-shadow: inset 0px 0px 0px 2px $nhs-black;
+    -moz-box-shadow: inset 0px 0px 0px 2px $nhs-black;
+    box-shadow: inset 0px 0px 0px 2px $nhs-black;
   }
 }
 

--- a/app/assets/sass/modules/radios-and-checkboxes.scss
+++ b/app/assets/sass/modules/radios-and-checkboxes.scss
@@ -56,8 +56,10 @@ input[type='radio']{
   width: 2.2rem;
   height: 2.2rem;
   background-color: #fff;
-  outline: 1px solid $nhs-black;
-  border: 2px solid $nhs-grey-2;
+  border: 1px solid $nhs-black;
+  -webkit-box-shadow: inset 0px 0px 0px 2px $nhs-grey-2;
+  -moz-box-shadow: inset 0px 0px 0px 2px $nhs-grey-2;
+  box-shadow: inset 0px 0px 0px 2px $nhs-grey-2;
 }
 
 // Make radios circles not boxes
@@ -77,7 +79,7 @@ input[type='radio']{
 // Checked style
 input[type='checkbox']:checked + .form-control-checkbox:before{
   content: "";
-  background: #FFF url(/public/images/tick.png) no-repeat 1px 1px;
+  background: $white url(/public/images/tick.png) no-repeat 1px 1px;
   background-size: 91%;
 }
 


### PR DESCRIPTION
Due to the ill considered use of `outline` and `border` to make the form elements, Safari wasn’t happy.

Switched to a `border` and `box-shadow` combo instead.

Also added a little clarity for `:focus` too.

Before:

<img width="335" alt="screen shot 2015-10-26 at 10 10 51" src="https://cloud.githubusercontent.com/assets/1913757/10726364/17f72134-7bca-11e5-9937-4741da156b1b.png">

After:

<img width="330" alt="screen shot 2015-10-26 at 10 11 12" src="https://cloud.githubusercontent.com/assets/1913757/10726365/17f7d020-7bca-11e5-9c01-2efd2865264c.png">

Focus:

<img width="328" alt="screen shot 2015-10-26 at 10 13 49" src="https://cloud.githubusercontent.com/assets/1913757/10726386/4994a2b6-7bca-11e5-83f0-064e79a5c53c.png">
