### PR TITLE
Add a template for planner cards

### DIFF
--- a/app/views/planner/cards/apply-for-free-prescriptions.html
+++ b/app/views/planner/cards/apply-for-free-prescriptions.html
@@ -1,0 +1,17 @@
+{% extends 'templates/planner_card.html' %}
+
+{% block id %}apply-for-free-prescriptions{% endblock %}
+
+{% block heading %}
+  Apply for free prescriptions
+{% endblock %}
+
+{% block leadin %}
+  <p>You're entitled to free prescriptions, but you must apply for this</p>
+
+  <p><a href="#" class="button item-permanent-cta">Apply now</a></p>
+{% endblock %}
+
+{% block body %}
+  <p>Nothing goes here?</p>
+{% endblock %}

--- a/app/views/planner/cards/medication.html
+++ b/app/views/planner/cards/medication.html
@@ -1,0 +1,44 @@
+{% extends 'templates/planner_card.html' %}
+
+{% block id %}metformin-info-card{% endblock %}
+
+{% block heading %}
+  Your Metformin medication
+{% endblock %}
+
+{% block body %}
+  <p>You picked up your latest prescription on 19 October 2015</p>
+
+  <dl>
+    <dt>You're on:</dt>
+    <dd>Metformin</dd>
+    <dt>How much:</dt>
+    <dd>1 tablet a day</dd>
+    <dt>When to take it:</dt>
+    <dd>after food, with water <small>(don't chew the tablets)</small></dd>
+  </dl>
+
+  <p>Metformin helps keep your blood sugar levels under control.</p>
+
+  <details>
+    <summary>More about Metformin</summary>
+
+    <p>Metformin works by:</p>
+
+    <ul class="list-bullet">
+      <li>reducing the amount of glucose released into your blood</li>
+      <li>helping the cells remove glucose from the blood</li>
+      <li>reducing the amount of glucose you absorb from your food</li>
+    </ul>
+
+    <p><a href="https://www.diabetes.org.uk/biguanide">Read more about Metformin at <strong>diabetes.org.uk</strong></a></p>
+  </details>
+
+  <p>It can cause side effects. Speak to your GP if you have:</p>
+
+  <ul class="list-bullet">
+    <li>bloating</li>
+    <li>diarrhoea</li>
+    <li>feeling sick</li>
+  </ul>
+{% endblock %}

--- a/app/views/planner/cards/repeat-prescription.html
+++ b/app/views/planner/cards/repeat-prescription.html
@@ -1,0 +1,28 @@
+{% extends 'templates/planner_card.html' %}
+
+{% block id %}repeat-prescription-card{% endblock %}
+
+{% block heading %}
+  Pick up your next Metformin prescription on 19 November 2015
+{% endblock %}
+
+{% block body %}
+  <p class="lede">30x500mg of Metformin tablets</p>
+
+  <p>Pick up from:</p>
+
+  <p>
+    Essentials Pharmacy<br>
+    169 Drury Lane<br>
+    London<br>
+    WC2B 5QA<br>
+    <a href="#">Show map</a>
+  </p>
+
+  <ul>
+    <li><a href="#">Send me a text reminder the day before</a></li>
+    <li><a href="#">Change my pharmacy</a></li>
+  </ul>
+
+  <p>You <strong>do not</strong> have to see your GP for this prescription</p>
+{% endblock %}

--- a/app/views/planner/index.html
+++ b/app/views/planner/index.html
@@ -1,0 +1,19 @@
+{% extends 'templates/nhs_transaction_layout.html' %}
+
+{% block afterHeader %}
+  <div class="service-header">
+    <div class="service-name">
+      Your planner for type 2 diabetes
+    </div>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <main id="content" role="main">
+    <div class="js-cards items-container">
+      {% include 'planner/cards/medication.html' %}
+      {% include 'planner/cards/apply-for-free-prescriptions.html' %}
+      {% include 'planner/cards/repeat-prescription.html' %}
+    </div>
+  </main>
+{% endblock %}

--- a/app/views/templates/planner_card.html
+++ b/app/views/templates/planner_card.html
@@ -1,0 +1,22 @@
+<div class="item {% block id %}{% endblock %}" id="{% block id %}{% endblock %}">
+  <div class="shadow"></div>
+  <div class="item-content">
+    <div class="item-header">
+      <a href="#{% block id %}{% endblock %}" class="item-collapse-link">
+	{% block heading %}{% endblock %}
+      </a>
+    </div>
+
+    <div class="item-leadin">
+      {% block leadin %}{% endblock %}
+    </div>
+
+    <div class="item-body item-body-collapsed">
+      {% block body %}{% endblock %}
+
+      <div class="item-collapse">
+	<a href="#" class="item-collapse-link" tabindex="0">Show less</a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Extending a template makes it easier to supply blocks of HTML than when using a macro.

This is very rough still:
- Currently the `leadin` and `body` block surrounds are present even if there's no content for them
- The ID probably doesn't need to be specified manually, at least not like this
- There's only three cards, and their presence and order is hardcoded right now.
- The styling on the definition list is completely off.
