### PR TITLE
Remove nesting from db/load promises

### DIFF
--- a/db/appointments.json
+++ b/db/appointments.json
@@ -1,164 +1,166 @@
-[
-  {
-    "uuid": "fb673682-cd97-41e7-9200-9567694e8f2d",
-    "appointment_date": "Tuesday 26th January 2016",
-    "appointment_time": "16:10",
-    "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
-    "appointment_length": "5",
-    "appointment_type": "telephone",
-    "appointment_type_class": "telephone"
-  },
-  {
-    "uuid": "954c2263-c737-4a76-a8e0-e7c44010529a",
-    "appointment_date": "Tuesday 26th January 2016",
-    "appointment_time": "16:30",
-    "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
-    "appointment_length": "10",
-    "appointment_type": "telephone",
-    "appointment_type_class": "telephone"
-  },
-  {
-    "uuid": "0e26582a-d984-4d43-ab74-13a2e9418499",
-    "appointment_date": "Wednesday 27th January 2016",
-    "appointment_time": "13:10",
-    "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
-    "appointment_length": "10",
-    "appointment_type": "telephone",
-    "appointment_type_class": "telephone"
-  },
-  {
-    "uuid": "514c03d8-2342-4878-b367-162acbef821a",
-    "appointment_date": "Thursday 28th January 2016",
-    "appointment_time": "11:30",
-    "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "8061a84d-99de-479f-b95e-749ee9a16764",
-    "appointment_date": "Thursday 28th January 2016",
-    "appointment_time": "16:10",
-    "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "7f52fa78-2446-44d0-99d4-0d8bba02b8b9",
-    "appointment_date": "Friday 29th January 2016",
-    "appointment_time": "08:30",
-    "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "5fd5c800-69dd-4ac8-b38d-903ec5a83740",
-    "appointment_date": "Friday 29th January 2016",
-    "appointment_time": "14:40",
-    "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "6ad52229-75da-4694-9c9d-a1803338637c",
-    "appointment_date": "Friday 29th January 2016",
-    "appointment_time": "16:10",
-    "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
-    "appointment_length": "5",
-    "appointment_type": "telephone",
-    "appointment_type_class": "telephone"
-  },
-  {
-    "uuid": "030faee3-ce8b-435e-a0da-2feaed676a8c",
-    "appointment_date": "Friday 29th January 2016",
-    "appointment_time": "16:30",
-    "practitioner_uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "9adacdae-9110-4b90-b047-5e0a4e6f5523",
-    "appointment_date": "Tuesday 2nd February 2016",
-    "appointment_time": "11:30",
-    "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "48258b48-a682-4e75-95f6-2b4c0618731d",
-    "appointment_date": "Tuesday 2nd February 2016",
-    "appointment_time": "13:10",
-    "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "ec6324e8-321b-42dd-a16c-20a626905d05",
-    "appointment_date": "Tuesday 2nd February 2016",
-    "appointment_time": "16:10",
-    "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "e7030644-fc92-4afb-917d-6c5e7672de99",
-    "appointment_date": "Tuesday 2nd February 2016",
-    "appointment_time": "16:10",
-    "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
-    "appointment_length": "5",
-    "appointment_type": "telephone",
-    "appointment_type_class": "telephone"
-  },
-  {
-    "uuid": "1a15390f-857e-4b5b-a311-9024f26fcfd7",
-    "appointment_date": "Wednesday 3rd February 2016",
-    "appointment_time": "08:30",
-    "practitioner_uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "eee7f992-607c-4d43-bca2-41ff51311840",
-    "appointment_date": "Wednesday 3rd February 2016",
-    "appointment_time": "11:30",
-    "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "939db37a-60b1-47c4-b005-672fddbbb62c",
-    "appointment_date": "Wednesday 3rd February 2016",
-    "appointment_time": "13:10",
-    "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "7e28899f-857e-4de3-91dd-8216d8836c92",
-    "appointment_date": "Wednesday 3rd February 2016",
-    "appointment_time": "16:10",
-    "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
-    "appointment_length": "10",
-    "appointment_type": "face to face",
-    "appointment_type_class": "face-to-face"
-  },
-  {
-    "uuid": "dbc9d1a1-4b78-47c4-937f-1c5e460491ec",
-    "appointment_date": "Wednesday 3rd February 2016",
-    "appointment_time": "15:10",
-    "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
-    "appointment_length": "5",
-    "appointment_type": "telephone",
-    "appointment_type_class": "telephone"
-  }
-]
+{
+  "appointments": [
+    {
+      "uuid": "fb673682-cd97-41e7-9200-9567694e8f2d",
+      "appointment_date": "Tuesday 26th January 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
+      "appointment_length": "5",
+      "appointment_type": "telephone",
+      "appointment_type_class": "telephone"
+    },
+    {
+      "uuid": "954c2263-c737-4a76-a8e0-e7c44010529a",
+      "appointment_date": "Tuesday 26th January 2016",
+      "appointment_time": "16:30",
+      "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "appointment_length": "10",
+      "appointment_type": "telephone",
+      "appointment_type_class": "telephone"
+    },
+    {
+      "uuid": "0e26582a-d984-4d43-ab74-13a2e9418499",
+      "appointment_date": "Wednesday 27th January 2016",
+      "appointment_time": "13:10",
+      "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "appointment_length": "10",
+      "appointment_type": "telephone",
+      "appointment_type_class": "telephone"
+    },
+    {
+      "uuid": "514c03d8-2342-4878-b367-162acbef821a",
+      "appointment_date": "Thursday 28th January 2016",
+      "appointment_time": "11:30",
+      "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "8061a84d-99de-479f-b95e-749ee9a16764",
+      "appointment_date": "Thursday 28th January 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "7f52fa78-2446-44d0-99d4-0d8bba02b8b9",
+      "appointment_date": "Friday 29th January 2016",
+      "appointment_time": "08:30",
+      "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "5fd5c800-69dd-4ac8-b38d-903ec5a83740",
+      "appointment_date": "Friday 29th January 2016",
+      "appointment_time": "14:40",
+      "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "6ad52229-75da-4694-9c9d-a1803338637c",
+      "appointment_date": "Friday 29th January 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
+      "appointment_length": "5",
+      "appointment_type": "telephone",
+      "appointment_type_class": "telephone"
+    },
+    {
+      "uuid": "030faee3-ce8b-435e-a0da-2feaed676a8c",
+      "appointment_date": "Friday 29th January 2016",
+      "appointment_time": "16:30",
+      "practitioner_uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "9adacdae-9110-4b90-b047-5e0a4e6f5523",
+      "appointment_date": "Tuesday 2nd February 2016",
+      "appointment_time": "11:30",
+      "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "48258b48-a682-4e75-95f6-2b4c0618731d",
+      "appointment_date": "Tuesday 2nd February 2016",
+      "appointment_time": "13:10",
+      "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "ec6324e8-321b-42dd-a16c-20a626905d05",
+      "appointment_date": "Tuesday 2nd February 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "e7030644-fc92-4afb-917d-6c5e7672de99",
+      "appointment_date": "Tuesday 2nd February 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
+      "appointment_length": "5",
+      "appointment_type": "telephone",
+      "appointment_type_class": "telephone"
+    },
+    {
+      "uuid": "1a15390f-857e-4b5b-a311-9024f26fcfd7",
+      "appointment_date": "Wednesday 3rd February 2016",
+      "appointment_time": "08:30",
+      "practitioner_uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "eee7f992-607c-4d43-bca2-41ff51311840",
+      "appointment_date": "Wednesday 3rd February 2016",
+      "appointment_time": "11:30",
+      "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "939db37a-60b1-47c4-b005-672fddbbb62c",
+      "appointment_date": "Wednesday 3rd February 2016",
+      "appointment_time": "13:10",
+      "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "7e28899f-857e-4de3-91dd-8216d8836c92",
+      "appointment_date": "Wednesday 3rd February 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
+      "appointment_length": "10",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face"
+    },
+    {
+      "uuid": "dbc9d1a1-4b78-47c4-937f-1c5e460491ec",
+      "appointment_date": "Wednesday 3rd February 2016",
+      "appointment_time": "15:10",
+      "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
+      "appointment_length": "5",
+      "appointment_type": "telephone",
+      "appointment_type_class": "telephone"
+    }
+  ]
+}

--- a/db/gp_practices.json
+++ b/db/gp_practices.json
@@ -1,244 +1,246 @@
-[
-  {
-    "slug": "lakeside-surgery",
-    "name": "Lakeside Surgery",
-    "address": [
-      "22 Castelnau",
-      "London",
-      "NW13 9HJ"
-    ],
-    "distance_away": "0.4 miles away",
-    "travel_time": "About a 6 minute walk",
-    "appointment_hours": {
-      "Monday": "9am – 4.50pm",
-      "Tuesday": "7.30am – 7.20pm",
-      "Wednesday": "9am – 4.50pm",
-      "Thursday": "9am – 4.50pm",
-      "Friday": "7.30am – 7.20pm"
-    },
-    "list_size": "2,000 patients",
-    "ratings": {
-      "would_recommend": "82%",
-      "feel_listened_to": "88%",
-      "wait_time": "8 days"
-    },
-    "services": [
-      "Travel vaccinations",
-      "Over 40 health check",
-      "Diabetes clinic",
-      "Childhood vaccinations",
-      "Quit smoking"
-    ],
-    "staff": {
-      "count": 7,
-      "doctors": [
-        {
-          "name": "Dr Helen Leaf",
-          "role": "GP",
-          "gender": "female",
-          "photo": "icon-avatar-helen-leaf.png"
-        },
-        {
-          "name": "Dr Mike Johnson",
-          "role": "GP",
-          "gender": "male",
-          "photo": "icon-avatar-mike-johnson.png"
-        },
-        {
-          "name": "Dr Emma Stace",
-          "role": "GP",
-          "gender": "female",
-          "photo": "icon-avatar.svg"
-        },
-        {
-          "name": "Dr Malcolm Branch",
-          "role": "GP",
-          "gender": "male",
-          "photo": "icon-avatar-malcolm-branch.png"
-        }
+{
+  "gp_practices": [
+    {
+      "slug": "lakeside-surgery",
+      "name": "Lakeside Surgery",
+      "address": [
+        "22 Castelnau",
+        "London",
+        "NW13 9HJ"
       ],
-      "nurse_practitioners": [
-        {
-          "name": "Sasheika Wrench",
-          "role": "Nurse practitioner",
-          "gender": "female",
-          "photo": "icon-avatar.svg"
-        },
-        {
-          "name": "Jonathan Hope",
-          "role": "Nurse practitioner",
-          "gender": "male",
-          "photo": "icon-avatar-jonathon-hope.png"
-        }
+      "distance_away": "0.4 miles away",
+      "travel_time": "About a 6 minute walk",
+      "appointment_hours": {
+        "Monday": "9am – 4.50pm",
+        "Tuesday": "7.30am – 7.20pm",
+        "Wednesday": "9am – 4.50pm",
+        "Thursday": "9am – 4.50pm",
+        "Friday": "7.30am – 7.20pm"
+      },
+      "list_size": "2,000 patients",
+      "ratings": {
+        "would_recommend": "82%",
+        "feel_listened_to": "88%",
+        "wait_time": "8 days"
+      },
+      "services": [
+        "Travel vaccinations",
+        "Over 40 health check",
+        "Diabetes clinic",
+        "Childhood vaccinations",
+        "Quit smoking"
       ],
-      "nurses": [
-        {
-          "name": "Alison Wylde",
-          "role": "Nurse",
-          "gender": "female",
-          "photo": "icon-avatar-alison-wylde.png"
-        }
-      ]
+      "staff": {
+        "count": 7,
+        "doctors": [
+          {
+            "name": "Dr Helen Leaf",
+            "role": "GP",
+            "gender": "female",
+            "photo": "icon-avatar-helen-leaf.png"
+          },
+          {
+            "name": "Dr Mike Johnson",
+            "role": "GP",
+            "gender": "male",
+            "photo": "icon-avatar-mike-johnson.png"
+          },
+          {
+            "name": "Dr Emma Stace",
+            "role": "GP",
+            "gender": "female",
+            "photo": "icon-avatar.svg"
+          },
+          {
+            "name": "Dr Malcolm Branch",
+            "role": "GP",
+            "gender": "male",
+            "photo": "icon-avatar-malcolm-branch.png"
+          }
+        ],
+        "nurse_practitioners": [
+          {
+            "name": "Sasheika Wrench",
+            "role": "Nurse practitioner",
+            "gender": "female",
+            "photo": "icon-avatar.svg"
+          },
+          {
+            "name": "Jonathan Hope",
+            "role": "Nurse practitioner",
+            "gender": "male",
+            "photo": "icon-avatar-jonathon-hope.png"
+          }
+        ],
+        "nurses": [
+          {
+            "name": "Alison Wylde",
+            "role": "Nurse",
+            "gender": "female",
+            "photo": "icon-avatar-alison-wylde.png"
+          }
+        ]
+      }
+    },
+    {
+      "slug": "shrewsbottom-surgery",
+      "name": "Shrewsbottom Surgery",
+      "address": [
+        "15 Pound Lane",
+        "London",
+        "NW12 9AT"
+      ],
+      "distance_away": "1.1 miles away",
+      "travel_time": "About a 20 minute walk",
+      "appointment_hours": {
+        "Monday to Friday": "9am – 5pm"
+      },
+      "list_size": "2,000 patients",
+      "ratings": {
+        "would_recommend": "89%",
+        "feel_listened_to": "88%",
+        "wait_time": "5 days"
+      },
+      "services": [
+        "Travel vaccinations",
+        "Over 40 health check",
+        "Diabetes clinic",
+        "Childhood vaccinations",
+        "Quit smoking"
+      ],
+      "staff": {
+        "count": 7,
+        "doctors": [
+          {
+            "name": "Dr Helen Leaf",
+            "role": "GP",
+            "gender": "female",
+            "photo": "icon-avatar-helen-leaf.png"
+          },
+          {
+            "name": "Dr Mike Johnson",
+            "role": "GP",
+            "gender": "male",
+            "photo": "icon-avatar-mike-johnson.png"
+          },
+          {
+            "name": "Dr Emma Stace",
+            "role": "GP",
+            "gender": "female",
+            "photo": "icon-avatar.svg"
+          },
+          {
+            "name": "Dr Malcolm Branch",
+            "role": "GP",
+            "gender": "male",
+            "photo": "icon-avatar-malcolm-branch.png"
+          }
+        ],
+        "nurse_practitioners": [
+          {
+            "name": "Sasheika Wrench",
+            "role": "Nurse practitioner",
+            "gender": "female",
+            "photo": "icon-avatar.svg"
+          },
+          {
+            "name": "Jonathan Hope",
+            "role": "Nurse practitioner",
+            "gender": "male",
+            "photo": "icon-avatar-jonathon-hope.png"
+          }
+        ],
+        "nurses": [
+          {
+            "name": "Alison Wylde",
+            "role": "Nurse",
+            "gender": "female",
+            "photo": "icon-avatar-alison-wylde.png"
+          }
+        ]
+      }
+    },
+    {
+      "slug": "victoria-medical-centre",
+      "name": "Victoria Medical Centre",
+      "address": [
+        "48 Buttoy",
+        "London",
+        "NW13 9HT"
+      ],
+      "distance_away": "1.5 miles away",
+      "travel_time": "About a 25 minute walk",
+      "appointment_hours": {
+        "Monday": "9am – 5pm",
+        "Tuesday": "9am – 5pm",
+        "Wednesday": "9am – 9pm",
+        "Thursday": "9am – 5pm",
+        "Friday": "9am – 5pm"
+      },
+      "list_size": "2,000 patients",
+      "ratings": {
+        "would_recommend": "74%",
+        "feel_listened_to": "88%",
+        "wait_time": "13 days"
+      },
+      "services": [
+        "Travel vaccinations",
+        "Over 40 health check",
+        "Diabetes clinic",
+        "Childhood vaccinations",
+        "Quit smoking"
+      ],
+      "staff": {
+        "count": 7,
+        "doctors": [
+          {
+            "name": "Dr Helen Leaf",
+            "role": "GP",
+            "gender": "female",
+            "photo": "icon-avatar-helen-leaf.png"
+          },
+          {
+            "name": "Dr Mike Johnson",
+            "role": "GP",
+            "gender": "male",
+            "photo": "icon-avatar-mike-johnson.png"
+          },
+          {
+            "name": "Dr Emma Stace",
+            "role": "GP",
+            "gender": "female",
+            "photo": "icon-avatar.svg"
+          },
+          {
+            "name": "Dr Malcolm Branch",
+            "role": "GP",
+            "gender": "male",
+            "photo": "icon-avatar-malcolm-branch.png"
+          }
+        ],
+        "nurse_practitioners": [
+          {
+            "name": "Sasheika Wrench",
+            "role": "Nurse practitioner",
+            "gender": "female",
+            "photo": "icon-avatar.svg"
+          },
+          {
+            "name": "Jonathan Hope",
+            "role": "Nurse practitioner",
+            "gender": "male",
+            "photo": "icon-avatar-jonathon-hope.png"
+          }
+        ],
+        "nurses": [
+          {
+            "name": "Alison Wylde",
+            "role": "Nurse",
+            "gender": "female",
+            "photo": "icon-avatar-alison-wylde.png"
+          }
+        ]
+      }
     }
-  },
-  {
-    "slug": "shrewsbottom-surgery",
-    "name": "Shrewsbottom Surgery",
-    "address": [
-      "15 Pound Lane",
-      "London",
-      "NW12 9AT"
-    ],
-    "distance_away": "1.1 miles away",
-    "travel_time": "About a 20 minute walk",
-    "appointment_hours": {
-      "Monday to Friday": "9am – 5pm"
-    },
-    "list_size": "2,000 patients",
-    "ratings": {
-      "would_recommend": "89%",
-      "feel_listened_to": "88%",
-      "wait_time": "5 days"
-    },
-    "services": [
-      "Travel vaccinations",
-      "Over 40 health check",
-      "Diabetes clinic",
-      "Childhood vaccinations",
-      "Quit smoking"
-    ],
-    "staff": {
-      "count": 7,
-      "doctors": [
-        {
-          "name": "Dr Helen Leaf",
-          "role": "GP",
-          "gender": "female",
-          "photo": "icon-avatar-helen-leaf.png"
-        },
-        {
-          "name": "Dr Mike Johnson",
-          "role": "GP",
-          "gender": "male",
-          "photo": "icon-avatar-mike-johnson.png"
-        },
-        {
-          "name": "Dr Emma Stace",
-          "role": "GP",
-          "gender": "female",
-          "photo": "icon-avatar.svg"
-        },
-        {
-          "name": "Dr Malcolm Branch",
-          "role": "GP",
-          "gender": "male",
-          "photo": "icon-avatar-malcolm-branch.png"
-        }
-      ],
-      "nurse_practitioners": [
-        {
-          "name": "Sasheika Wrench",
-          "role": "Nurse practitioner",
-          "gender": "female",
-          "photo": "icon-avatar.svg"
-        },
-        {
-          "name": "Jonathan Hope",
-          "role": "Nurse practitioner",
-          "gender": "male",
-          "photo": "icon-avatar-jonathon-hope.png"
-        }
-      ],
-      "nurses": [
-        {
-          "name": "Alison Wylde",
-          "role": "Nurse",
-          "gender": "female",
-          "photo": "icon-avatar-alison-wylde.png"
-        }
-      ]
-    }
-  },
-  {
-    "slug": "victoria-medical-centre",
-    "name": "Victoria Medical Centre",
-    "address": [
-      "48 Buttoy",
-      "London",
-      "NW13 9HT"
-    ],
-    "distance_away": "1.5 miles away",
-    "travel_time": "About a 25 minute walk",
-    "appointment_hours": {
-      "Monday": "9am – 5pm",
-      "Tuesday": "9am – 5pm",
-      "Wednesday": "9am – 9pm",
-      "Thursday": "9am – 5pm",
-      "Friday": "9am – 5pm"
-    },
-    "list_size": "2,000 patients",
-    "ratings": {
-      "would_recommend": "74%",
-      "feel_listened_to": "88%",
-      "wait_time": "13 days"
-    },
-    "services": [
-      "Travel vaccinations",
-      "Over 40 health check",
-      "Diabetes clinic",
-      "Childhood vaccinations",
-      "Quit smoking"
-    ],
-    "staff": {
-      "count": 7,
-      "doctors": [
-        {
-          "name": "Dr Helen Leaf",
-          "role": "GP",
-          "gender": "female",
-          "photo": "icon-avatar-helen-leaf.png"
-        },
-        {
-          "name": "Dr Mike Johnson",
-          "role": "GP",
-          "gender": "male",
-          "photo": "icon-avatar-mike-johnson.png"
-        },
-        {
-          "name": "Dr Emma Stace",
-          "role": "GP",
-          "gender": "female",
-          "photo": "icon-avatar.svg"
-        },
-        {
-          "name": "Dr Malcolm Branch",
-          "role": "GP",
-          "gender": "male",
-          "photo": "icon-avatar-malcolm-branch.png"
-        }
-      ],
-      "nurse_practitioners": [
-        {
-          "name": "Sasheika Wrench",
-          "role": "Nurse practitioner",
-          "gender": "female",
-          "photo": "icon-avatar.svg"
-        },
-        {
-          "name": "Jonathan Hope",
-          "role": "Nurse practitioner",
-          "gender": "male",
-          "photo": "icon-avatar-jonathon-hope.png"
-        }
-      ],
-      "nurses": [
-        {
-          "name": "Alison Wylde",
-          "role": "Nurse",
-          "gender": "female",
-          "photo": "icon-avatar-alison-wylde.png"
-        }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/db/load.js
+++ b/db/load.js
@@ -22,27 +22,19 @@ function load_data_files() {
       return file_name.match(/\.json$/);
     })
     .map(function(file_name) {
-      return fs.readFileAsync(__dirname + '/' + file_name, 'utf8')
-        .then(JSON.parse)
-        .then(function(data) {
-          var dataset_name = file_name.replace(/\.json$/, ''),
-              o = {};
-
-          o[dataset_name] = data;
-
-          return o;
-        })
-        .catch(SyntaxError, function(e) {
-          console.error('invalid JSON in file ' + file_name);
-          throw(e);
-        })
-        .catch(function(e) {
-          console.log('unable to read file ' + file_name);
-          throw(e);
-        });
+      return fs.readFileAsync(__dirname + '/' + file_name, 'utf8');
     })
+    .map(JSON.parse)
     .reduce(function(a, b) {
       return util._extend(a, b);
+    })
+    .catch(SyntaxError, function(e) {
+      console.error('invalid JSON in file ' + file_name);
+      throw(e);
+    })
+    .catch(function(e) {
+      console.log('unable to read file ' + file_name);
+      throw(e);
     });
 }
 

--- a/db/practitioners.json
+++ b/db/practitioners.json
@@ -1,51 +1,53 @@
-[
-  {
-    "uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
-    "name": "Dr Helen Leaf",
-    "role": "GP",
-    "gender": "female",
-    "photo": "icon-avatar-helen-leaf.png"
-  },
-  {
-    "uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
-    "name": "Dr Mike Johnson",
-    "role": "GP",
-    "gender": "male",
-    "photo": "icon-avatar-mike-johnson.png"
-  },
-  {
-    "uuid": "ae6c5edc-e16b-4230-a4d9-94d02cd64884",
-    "name": "Dr Emma Stace",
-    "role": "GP",
-    "gender": "female",
-    "photo": "icon-avatar.svg"
-  },
-  {
-    "uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
-    "name": "Dr Malcolm Branch",
-    "role": "GP",
-    "gender": "male",
-    "photo": "icon-avatar-malcolm-branch.png"
-  },
-  {
-    "uuid": "29316adc-ea1d-408f-8180-0eb64073dbd9",
-    "name": "Sasheika Wrench",
-    "role": "Nurse practitioner",
-    "gender": "female",
-    "photo": "icon-avatar.svg"
-  },
-  {
-    "uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
-    "name": "Jonathan Hope",
-    "role": "Nurse practitioner",
-    "gender": "male",
-    "photo": "icon-avatar-jonathon-hope.png"
-  },
-  {
-    "uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
-    "name": "Alison Wylde",
-    "role": "Nurse",
-    "gender": "female",
-    "photo": "icon-avatar-alison-wylde.png"
-  }
-]
+{
+  "practitioners": [
+    {
+      "uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
+      "name": "Dr Helen Leaf",
+      "role": "GP",
+      "gender": "female",
+      "photo": "icon-avatar-helen-leaf.png"
+    },
+    {
+      "uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
+      "name": "Dr Mike Johnson",
+      "role": "GP",
+      "gender": "male",
+      "photo": "icon-avatar-mike-johnson.png"
+    },
+    {
+      "uuid": "ae6c5edc-e16b-4230-a4d9-94d02cd64884",
+      "name": "Dr Emma Stace",
+      "role": "GP",
+      "gender": "female",
+      "photo": "icon-avatar.svg"
+    },
+    {
+      "uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
+      "name": "Dr Malcolm Branch",
+      "role": "GP",
+      "gender": "male",
+      "photo": "icon-avatar-malcolm-branch.png"
+    },
+    {
+      "uuid": "29316adc-ea1d-408f-8180-0eb64073dbd9",
+      "name": "Sasheika Wrench",
+      "role": "Nurse practitioner",
+      "gender": "female",
+      "photo": "icon-avatar.svg"
+    },
+    {
+      "uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
+      "name": "Jonathan Hope",
+      "role": "Nurse practitioner",
+      "gender": "male",
+      "photo": "icon-avatar-jonathon-hope.png"
+    },
+    {
+      "uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "name": "Alison Wylde",
+      "role": "Nurse",
+      "gender": "female",
+      "photo": "icon-avatar-alison-wylde.png"
+    }
+  ]
+}


### PR DESCRIPTION
Rather than having a big chunk of work nested inside the `map` call, flatten it out so we do all the work at the same level.

To make that easier, push the work of creating the dataset name from the file name into the JSON.
