### PR TITLE
Add diabetes review cards

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -244,24 +244,29 @@ module.exports = {
 
     app.get('/planner', function(req, res) {
       var booked_eye_test = !!req.query.booked_eye_test,
-          cards;
+          booked_diabetes_review = !!req.query.booked_diabetes_review,
+          cards = [];
 
+      // historic stuff
+      cards.push('medication');
+
+      // actions to take
+      if (!booked_diabetes_review) {
+        cards.push('book-your-first-diabetes-review');
+      }
+      if (!booked_eye_test) {
+        cards.push('book-your-first-eye-test');
+      }
+      cards.push('apply-for-free-prescriptions');
+
+      // upcoming stuff
+      if (booked_diabetes_review) {
+        cards.push('your-diabetes-review-appointment');
+      }
       if (booked_eye_test) {
-        cards = [
-          'medication',
-          'apply-for-free-prescriptions',
-          'your-eye-test-appointment',
-          'repeat-prescription'
-        ];
+        cards.push('your-eye-test-appointment');
       }
-      else {
-        cards = [
-          'medication',
-          'book-your-first-eye-test',
-          'apply-for-free-prescriptions',
-          'repeat-prescription'
-        ];
-      }
+      cards.push('repeat-prescription');
 
       res.render(
         'planner/index',

--- a/app/views/planner/cards/book-your-first-diabetes-review.html
+++ b/app/views/planner/cards/book-your-first-diabetes-review.html
@@ -1,0 +1,33 @@
+{% extends 'templates/planner_card.html' %}
+
+{% block id %}book-your-first-diabetes-review{% endblock %}
+
+{% block heading %}
+  Book your first diabetes review
+{% endblock %}
+
+{% block leadin %}
+  <p>The review checks your average blood sugar levels and how close they are
+  to normal. It also checks your general health.</p>
+
+  <p><a href="#" class="button item-permanent-cta button-get-started">
+    Book your diabetes review now
+  </a></p>
+{% endblock %}
+
+{% block body %}
+  <p>You should book your first diabetes review as soon as you are diagnosed
+  with type 2 diabetes. Until your blood sugar levels are healthy you should
+  have your blood sugar levels checked every 3 months.</p>
+
+  <p>At the review you’ll have:</p>
+
+  <ul class="list-bullet">
+    <li>a blood test for blood sugar and cholesterol levels</li>
+    <li>your blood pressure taken</li>
+    <li>a urine test for kidney function</li>
+    <li>your weight and height measured</li>
+  </ul>
+
+  <p><a href="#">Health problems caused by type 2 diabetes</a></p>
+{% endblock %}

--- a/app/views/planner/cards/your-diabetes-review-appointment.html
+++ b/app/views/planner/cards/your-diabetes-review-appointment.html
@@ -1,0 +1,26 @@
+{% extends 'templates/planner_card.html' %}
+
+{% block id %}your-diabetes-review-appointment{% endblock %}
+
+{% block heading %}
+  Your diabetes review appointment
+{% endblock %}
+
+{% block leadin %}
+  <p>Wednesday 28 October 2015 from 9:00am to 9:30am</p>
+{% endblock %}
+
+{% block body %}
+  <p>Covent Garden Medical Centre<br>
+  47 Shorts Gardens<br>
+  London<br>
+  WC2H 9AA</p>
+
+  <p>Sasheika Wrench<br>
+  Nurse practitioner, female</p>
+
+  <ul>
+    <li><a href="#">Send me a text reminder the day before</a></li>
+    <li><a href="#">Change appointment</a></li>
+  </ul>
+{% endblock %}


### PR DESCRIPTION
One for an action to book it, one for a reminder for a booked appointment.

Rejig how we're building the list. We're still using query parameters to work out the state, but now add the cards in one at a time.

This avoids having to enumerate all the possible list combinations based on the query string.

Once we allow not-hardcoded appointments to be booked, the ordering will probably end up horribly wrong. Classifying that as a problem for another time.
