### PR TITLE
First stab at wiring booking into the planner

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -304,6 +304,26 @@ module.exports = {
       );
     });
 
+    app.get('/planner/book-diabetes-review', function(req, res) {
+      var query = req.query,
+          service_slug = 'diabetes-annual-review';
+
+      // work out a return URL
+      query.booked_diabetes_review = 'true';
+      var return_url = '/planner?' + querystring.stringify(query);
+
+      // set the return URL in the session
+      if (!req.session.service_booking_offramp) {
+        req.session.service_booking_offramp = {};
+      }
+      req.session.service_booking_offramp[service_slug] = return_url;
+
+      // redirect to the service booking journey, skipping log in
+      res.redirect(
+        '/booking-with-context/next-available-appointment?service=' + service_slug
+      );
+    });
+
     app.get('/planner/book-eye-test', function(req, res) {
       var query = req.query,
           service_slug = 'diabetes-eye-screening';

--- a/app/views/planner/cards/book-your-first-diabetes-review.html
+++ b/app/views/planner/cards/book-your-first-diabetes-review.html
@@ -10,7 +10,7 @@
   <p>The review checks your average blood sugar levels and how close they are
   to normal. It also checks your general health.</p>
 
-  <p><a href="#" class="button item-permanent-cta button-get-started">
+  <p><a href="/planner/book-diabetes-review?{{ querystring }}" class="button item-permanent-cta button-get-started">
     Book your diabetes review now
   </a></p>
 {% endblock %}

--- a/app/views/planner/cards/book-your-first-eye-test.html
+++ b/app/views/planner/cards/book-your-first-eye-test.html
@@ -10,7 +10,7 @@
   <p>This checks if there's damage to your eyes which can lead to sight
   problems and possibly blindness.</p>
 
-  <p><a href="#" class="button item-permanent-cta button-get-started">
+  <p><a href="/planner/book-eye-test?{{ querystring }}" class="button item-permanent-cta button-get-started">
     Book your eye test now
   </a></p>
 


### PR DESCRIPTION
Add a route to start the eye test booking journey. It sets a session containing the return URL to be used at the end of the booking.

Change the booking confirmation route to check for the offramp return URL. If it finds one, redirect to it. If not, render the confirmation page as usual.

Also clear the session when using the log in/enter your details page, as it suggests the user hasn't come from a place where we need or want offramps to work.

Ideally the appointment confirmation card should be open and centred when the planner is loaded after return, but I'm going to leave that exercise for a future piece of work.
