### PR TITLE
Integrate "book a service" into main booking flow

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -205,10 +205,16 @@ module.exports = {
     });
 
     app.get('/book-an-appointment/:service_slug?/appointment-confirmed/:uuid', function(req, res) {
+      var service_slug = req.params.service_slug || 'general-practice',
+          service = app.locals.services.filter(function(service) {
+            return service.slug === service_slug;
+          })[0];
+
       res.render(
         'book-an-appointment/appointment-confirmed',
         {
           practice: app.locals.gp_practices[0],
+          service: service,
           appointment: find_appointment(req.params.uuid)
         }
       );

--- a/app/routes.js
+++ b/app/routes.js
@@ -159,21 +159,26 @@ module.exports = {
       );
     });
 
+    app.get('/book-an-appointment/:service_slug?/find-new-appointment', function(req, res) {
+      res.render('book-an-appointment/find-new-appointment');
+    });
+
     app.get('/book-an-appointment/:service_slug?/next-available-appointment', function(req, res) {
 
-      var service_slug = req.params.service_slug,
+      var service_slug = req.params.service_slug || 'general-practice',
           service = app.locals.services.filter(function(service) {
             return service.slug === service_slug;
-          })[0];
+          })[0],
+          practice = service_slug === 'general-practice' ? app.locals.gp_practices[0] : null;
 
       res.render(
         'book-an-appointment/next-available-appointment',
         {
-          practice: app.locals.gp_practices[0],
+          practice: practice,
           service: service,
           appointments: {
-            next: find_matching_appointment([filterByService('general-practice')]),
-            face_to_face: find_matching_appointment([filterByService('general-practice'),filterFaceToFace]),
+            next: find_matching_appointment([filterByService(service_slug)]),
+            face_to_face: find_matching_appointment([filterByService(service_slug),filterFaceToFace]),
           }
         }
       );
@@ -189,7 +194,7 @@ module.exports = {
       );
     });
 
-    app.get('/book-an-appointment/confirm-appointment/:uuid', function(req, res) {
+    app.get('/book-an-appointment/:service_slug?/confirm-appointment/:uuid', function(req, res) {
       res.render(
         'book-an-appointment/confirm-appointment',
         {
@@ -199,7 +204,7 @@ module.exports = {
       );
     });
 
-    app.get('/book-an-appointment/appointment-confirmed/:uuid', function(req, res) {
+    app.get('/book-an-appointment/:service_slug?/appointment-confirmed/:uuid', function(req, res) {
       res.render(
         'book-an-appointment/appointment-confirmed',
         {

--- a/app/routes.js
+++ b/app/routes.js
@@ -122,9 +122,9 @@ module.exports = {
         {
           practice: app.locals.gp_practices[0],
           appointments: {
-            next: find_matching_appointment([]),
-            face_to_face: find_matching_appointment([filterFaceToFace]),
-            early: find_matching_appointment([filterBefore10]),
+            next: find_matching_appointment([filterByService('general-practice')]),
+            face_to_face: find_matching_appointment([filterByService('general-practice'),filterFaceToFace]),
+            early: find_matching_appointment([filterByService('general-practice'),filterBefore10]),
           }
         }
       );
@@ -136,9 +136,9 @@ module.exports = {
         {
           practice: app.locals.gp_practices[0],
           appointments: {
-            next: find_matching_appointment([]),
-            face_to_face: find_matching_appointment([filterFaceToFace]),
-            female_gp: find_matching_appointment([filterFemaleGP])
+            next: find_matching_appointment([filterByService('general-practice')]),
+            face_to_face: find_matching_appointment([filterByService('general-practice'),filterFaceToFace]),
+            female_gp: find_matching_appointment([filterByService('general-practice'),filterFemaleGP])
           }
         }
       );
@@ -150,10 +150,10 @@ module.exports = {
         {
           practice: app.locals.gp_practices[0],
           appointments: {
-            next: find_matching_appointment([]),
-            face_to_face: find_matching_appointment([filterFaceToFace]),
-            female_gp: find_matching_appointment([filterFemaleGP]),
-            early_female_gp: find_matching_appointment([filterFemaleGP, filterBefore10])
+            next: find_matching_appointment([filterByService('general-practice')]),
+            face_to_face: find_matching_appointment([filterByService('general-practice'),filterFaceToFace]),
+            female_gp: find_matching_appointment([filterByService('general-practice'),filterFemaleGP]),
+            early_female_gp: find_matching_appointment([filterByService('general-practice'),filterFemaleGP, filterBefore10])
           }
         }
       );
@@ -165,8 +165,8 @@ module.exports = {
         {
           practice: app.locals.gp_practices[0],
           appointments: {
-            next: find_matching_appointment([]),
-            face_to_face: find_matching_appointment([filterFaceToFace]),
+            next: find_matching_appointment([filterByService('general-practice')]),
+            face_to_face: find_matching_appointment([filterByService('general-practice'),filterFaceToFace]),
           }
         }
       );
@@ -357,6 +357,12 @@ module.exports = {
     });
   }
 };
+
+var filterByService = function(service_slug) {
+  return function(appointment) {
+    return appointment.service === service_slug;
+  }
+}
 
 var filterFaceToFace = function(appointment) {
   return appointment.appointment_type == 'face to face';

--- a/app/routes.js
+++ b/app/routes.js
@@ -243,18 +243,25 @@ module.exports = {
     // Booking with context - from "service" query parameter, pass in details
     // about the session.
     app.get('/booking-with-context/next-available-appointment', function(req, res) {
+      var service_slug = req.query.service,
+          service = app.locals.services.filter(function(service) {
+            return service.slug === service_slug;
+          })[0];
+
       res.render(
         'booking-with-context/next-available-appointment',
         {
-          service_context: details_for_service(req.query.service),
-          appointment: appointment_for_service(req.query.service)
+          service_context: service,
+          appointment: appointment_for_service(service_slug)
         }
       );
     });
 
     app.get('/booking-with-context/appointment-confirmed', function(req, res) {
       var service_slug = req.query.service,
-          service_context = appointment_details_for_service(service_slug),
+          service = app.locals.services.filter(function(service) {
+            return service.slug === service_slug;
+          })[0],
           offramp = req.session.service_booking_offramp &&
                     req.session.service_booking_offramp[service_slug];
 
@@ -266,7 +273,7 @@ module.exports = {
         res.render(
           'booking-with-context/appointment-confirmed',
           {
-            service_context: service_context,
+            service_context: service,
             appointment: appointment_for_service(service_slug)
           }
         );
@@ -367,56 +374,6 @@ var filterBefore10 = function(appointment) {
 var filterByPractitionerUuid = function(uuid) {
   return function(appointment) {
     return appointment.practitioner_uuid === uuid;
-  }
-}
-
-function details_for_service(slug) {
-  switch(slug) {
-    case 'diabetes-blood-glucose-test' :
-      return {
-        name: 'Blood sugar test',
-        triage_hint: '<p>In your GP practice, blood sugar test appointments ' +
-                       'are carried out by a practice nurse.</p>',
-        confirmation_hint: "<p>The glycated haemoglobin (HbA1c) test gives your average blood glucose levels over the previous two to three months. The results can indicate whether the measures you're taking to control your diabetes are working.</p>" +
-          "<p>Unlike other tests the HbA1c test can be carried out at any time of day and it doesn't require any special preparation, such as fasting.</p>" +
-          "<p>The test will involve taking a small sample of blood from a vein.</p>",
-      };
-
-    case 'diabetes-foot-check' :
-      return {
-        name: 'Diabetes foot check',
-        triage_hint: '<p>In your GP practice, diabetes foot checks are carried ' +
-                     'out by a practice nurse.</p>',
-        confirmation_hint: "<p>People with diabetes have a much greater risk of " +
-          "developing problems with their feet. It is therefore important to " +
-          "have your feet examined regularly or if you have cuts or bruises.</p>" +
-          "<p>You will be asked to remove " +
-          "any footwear and the healthcare professional will examine your feet.</p>" +
-          "<p>The charity Diabetes UK has information on <a href='https://www.diabetes.org.uk/Documents/Guide%20to%20diabetes/monitoring/What-to-expect-at-annual-foot-check.pdf'>what to expect at your annual foot check.</a>",
-      };
-
-    case 'diabetes-eye-screening' :
-      return {
-        name: 'Diabetes eye screening',
-        triage_hint: '<p>For your GP practice, diabetic eye screening is ' +
-                     'carried out at:</p>' +
-                     '<p>The Royal Hospital<br>34 Queen\'s Avenue<br>SW14 4JR</p>',
-        confirmation_hint: '<p>People with diabetes are at risk of eye damage from diabetic retinopathy. Screening is a way of detecting the condition early before you notice any changes to your vision.</p>' +
-          '<p>The check takes about half an hour and involves examining the back of the eyes and taking photographs of the retina.</p>' +
-          '<p>If you wear glasses, bring these with you to the appointment.</p>' +
-          '<p>It is also advisable to bring sunglasses with you to help on the way home. When your pupils expand, lights will become brighter.</p>' +
-          '<p>The charity Diabetes UK have further <a href="http://www.diabetes.co.uk/diabetes-complications/retinopathy-screening.html">information about eye screening appointments.</a></p>',
-      };
-
-    case 'diabetes-annual-review' :
-      return {
-        name: 'Diabetes annual review',
-        triage_hint: '<p>In your GP practice, diabetes annual reviews are ' +
-                     'carried out by a nurse practitioner.</p>',
-        confirmation_hint: '<p>Your diabetic review will allow your doctors to monitor your health and assess aspects such as your long term blood glucose control, cholesterol levels and blood pressure.</p>' +
-          '<p>Because the review covers a lot of different things, it can be useful to bring a notebook and pen.</p>' +
-          '<p>The charity Diabetes UK have <a href="http://www.diabetes.co.uk/nhs/diabetes-annual-care-review.html">information about the diabetes annual review.</a></p>',
-      };
   }
 }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -243,10 +243,13 @@ module.exports = {
     // Booking with context - from "service" query parameter, pass in details
     // about the session.
     app.get('/booking-with-context/next-available-appointment', function(req, res) {
-      var service_context = appointment_details_for_service(req.query.service);
-
-      res.render('booking-with-context/next-available-appointment',
-                 {"service_context": service_context});
+      res.render(
+        'booking-with-context/next-available-appointment',
+        {
+          service_context: details_for_service(req.query.service),
+          appointment: appointment_for_service(req.query.service)
+        }
+      );
     });
 
     app.get('/booking-with-context/appointment-confirmed', function(req, res) {
@@ -263,7 +266,8 @@ module.exports = {
         res.render(
           'booking-with-context/appointment-confirmed',
           {
-            service_context: service_context
+            service_context: service_context,
+            appointment: appointment_for_service(service_slug)
           }
         );
       }
@@ -366,7 +370,7 @@ var filterByPractitionerUuid = function(uuid) {
   }
 }
 
-function appointment_details_for_service(slug) {
+function details_for_service(slug) {
   switch(slug) {
     case 'diabetes-blood-glucose-test' :
       return {
@@ -376,22 +380,6 @@ function appointment_details_for_service(slug) {
         confirmation_hint: "<p>The glycated haemoglobin (HbA1c) test gives your average blood glucose levels over the previous two to three months. The results can indicate whether the measures you're taking to control your diabetes are working.</p>" +
           "<p>Unlike other tests the HbA1c test can be carried out at any time of day and it doesn't require any special preparation, such as fasting.</p>" +
           "<p>The test will involve taking a small sample of blood from a vein.</p>",
-
-        appointment: {
-          link_url: 'appointment-confirmed?service=' + slug,
-          appointment_date: 'Tuesday 26th January 2016',
-          appointment_time: '16:10',
-          avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
-          name: 'Alison Wylde',
-          position: 'Nurse',
-          gender: 'female',
-          appointment_length: '5',
-          appointment_type: 'face to face',
-          appointment_type_class: 'face-to-face',
-          address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ',
-          tools: 'true'
-        }
-
       };
 
     case 'diabetes-foot-check' :
@@ -405,21 +393,6 @@ function appointment_details_for_service(slug) {
           "<p>You will be asked to remove " +
           "any footwear and the healthcare professional will examine your feet.</p>" +
           "<p>The charity Diabetes UK has information on <a href='https://www.diabetes.org.uk/Documents/Guide%20to%20diabetes/monitoring/What-to-expect-at-annual-foot-check.pdf'>what to expect at your annual foot check.</a>",
-        appointment: {
-          link_url: 'appointment-confirmed?service=' + slug,
-          appointment_date: 'Tuesday 26th January 2016',
-          appointment_time: '16:10',
-          avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
-          name: 'Alison Wylde',
-          position: 'Nurse',
-          gender: 'female',
-          appointment_length: '20',
-          appointment_type: 'face to face',
-          appointment_type_class: 'face-to-face',
-          address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ',
-          tools: 'true'
-        }
-
       };
 
     case 'diabetes-eye-screening' :
@@ -433,21 +406,6 @@ function appointment_details_for_service(slug) {
           '<p>If you wear glasses, bring these with you to the appointment.</p>' +
           '<p>It is also advisable to bring sunglasses with you to help on the way home. When your pupils expand, lights will become brighter.</p>' +
           '<p>The charity Diabetes UK have further <a href="http://www.diabetes.co.uk/diabetes-complications/retinopathy-screening.html">information about eye screening appointments.</a></p>',
-        appointment: {
-          link_url: 'appointment-confirmed?service=' + slug,
-          appointment_date: 'Tuesday 26th January 2016',
-          appointment_time: '16:10',
-          avatar_img_path: '/public/images/icon-avatar-ravi-aggarwal.png',
-          name: 'Ravi Aggarwal',
-          position: 'Nurse',
-          gender: 'male',
-          appointment_length: '30',
-          appointment_type: 'face to face',
-          appointment_type_class: 'face-to-face',
-          address: 'The Royal Hospital<br>34 Queen’s Avenue<br>London<br>NW13 9HJ',
-          tools: 'true'
-        }
-
       };
 
     case 'diabetes-annual-review' :
@@ -458,21 +416,74 @@ function appointment_details_for_service(slug) {
         confirmation_hint: '<p>Your diabetic review will allow your doctors to monitor your health and assess aspects such as your long term blood glucose control, cholesterol levels and blood pressure.</p>' +
           '<p>Because the review covers a lot of different things, it can be useful to bring a notebook and pen.</p>' +
           '<p>The charity Diabetes UK have <a href="http://www.diabetes.co.uk/nhs/diabetes-annual-care-review.html">information about the diabetes annual review.</a></p>',
-        appointment: {
-          link_url: 'appointment-confirmed?service=' + slug,
-          appointment_date: 'Monday 25th January 2016',
-          appointment_time: '11.20',
-          avatar_img_path: '/public/images/icon-avatar-jonathon-hope.png',
-          name: 'Jonathon Hope',
-          position: 'Nurse practitioner',
-          gender: 'male',
-          appointment_length: '25',
-          appointment_type: 'face to face',
-          appointment_type_class: 'face-to-face',
-          address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ',
-          tools: 'true'
-        }
+      };
+  }
+}
 
+function appointment_for_service(slug) {
+  switch(slug) {
+    case 'diabetes-blood-glucose-test' :
+      return {
+        link_url: 'appointment-confirmed?service=' + slug,
+        appointment_date: 'Tuesday 26th January 2016',
+        appointment_time: '16:10',
+        avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
+        name: 'Alison Wylde',
+        position: 'Nurse',
+        gender: 'female',
+        appointment_length: '5',
+        appointment_type: 'face to face',
+        appointment_type_class: 'face-to-face',
+        address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ',
+        tools: 'true'
+      };
+
+    case 'diabetes-foot-check' :
+      return {
+        link_url: 'appointment-confirmed?service=' + slug,
+        appointment_date: 'Tuesday 26th January 2016',
+        appointment_time: '16:10',
+        avatar_img_path: '/public/images/icon-avatar-alison-wylde.png',
+        name: 'Alison Wylde',
+        position: 'Nurse',
+        gender: 'female',
+        appointment_length: '20',
+        appointment_type: 'face to face',
+        appointment_type_class: 'face-to-face',
+        address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ',
+        tools: 'true'
+      };
+
+    case 'diabetes-eye-screening' :
+      return {
+        link_url: 'appointment-confirmed?service=' + slug,
+        appointment_date: 'Tuesday 26th January 2016',
+        appointment_time: '16:10',
+        avatar_img_path: '/public/images/icon-avatar-ravi-aggarwal.png',
+        name: 'Ravi Aggarwal',
+        position: 'Nurse',
+        gender: 'male',
+        appointment_length: '30',
+        appointment_type: 'face to face',
+        appointment_type_class: 'face-to-face',
+        address: 'The Royal Hospital<br>34 Queen’s Avenue<br>London<br>NW13 9HJ',
+        tools: 'true'
+      };
+
+    case 'diabetes-annual-review' :
+      return {
+        link_url: 'appointment-confirmed?service=' + slug,
+        appointment_date: 'Monday 25th January 2016',
+        appointment_time: '11.20',
+        avatar_img_path: '/public/images/icon-avatar-jonathon-hope.png',
+        name: 'Jonathon Hope',
+        position: 'Nurse practitioner',
+        gender: 'male',
+        appointment_length: '25',
+        appointment_type: 'face to face',
+        appointment_type_class: 'face-to-face',
+        address: 'Lakeside Surgery<br>22 Castelnau<br>London<br>NW13 9HJ',
+        tools: 'true'
       };
   }
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -159,11 +159,18 @@ module.exports = {
       );
     });
 
-    app.get('/book-an-appointment/next-available-appointment', function(req, res) {
+    app.get('/book-an-appointment/:service_slug?/next-available-appointment', function(req, res) {
+
+      var service_slug = req.params.service_slug,
+          service = app.locals.services.filter(function(service) {
+            return service.slug === service_slug;
+          })[0];
+
       res.render(
         'book-an-appointment/next-available-appointment',
         {
           practice: app.locals.gp_practices[0],
+          service: service,
           appointments: {
             next: find_matching_appointment([filterByService('general-practice')]),
             face_to_face: find_matching_appointment([filterByService('general-practice'),filterFaceToFace]),

--- a/app/routes.js
+++ b/app/routes.js
@@ -366,62 +366,6 @@ var filterByPractitionerUuid = function(uuid) {
   }
 }
 
-
-function practitioner_details_for_slug(slug) {
-  switch(slug) {
-    case 'helen-leaf':
-      return {
-        name: 'Dr Helen Leaf',
-        position: 'GP',
-        gender: 'female',
-        avatar: '/public/images/icon-avatar-helen-leaf.png'
-      };
-    case 'mike-johnson':
-      return {
-        name: 'Dr Mike Johnson',
-        position: 'GP',
-        gender: 'male',
-        avatar: '/public/images/icon-avatar-mike-johnson.png'
-      };
-    case 'emma-stace':
-      return {
-        name: 'Dr Emma Stace',
-        position: 'GP',
-        gender: 'female',
-        avatar: '/public/images/icon-avatar.svg'
-      };
-    case 'malcolm-branch':
-      return {
-        name: 'Dr Malcolm Branch',
-        position: 'GP',
-        gender: 'male',
-        avatar: '/public/images/icon-avatar-malcolm-branch.png'
-      };
-    case 'sasheika-wrench':
-      return {
-        name: 'Sasheika Wrench',
-        position: 'Nurse practitioner',
-        gender: 'female',
-        avatar: '/public/images/icon-avatar.svg'
-      };
-    case 'jonathon-hope':
-      return {
-        name: 'Jonathon Hope',
-        position: 'Nurse practitioner',
-        gender: 'male',
-        avatar: '/public/images/icon-avatar-jonathon-hope.png'
-      };
-    case 'alison-wylde':
-      return {
-        name: 'Alison Wylde',
-        position: 'Nurse',
-        gender: 'female',
-        avatar: '/public/images/icon-avatar-alison-wylde.png'
-      };
-  }
-}
-
-
 function appointment_details_for_service(slug) {
   switch(slug) {
     case 'diabetes-blood-glucose-test' :

--- a/app/routes.js
+++ b/app/routes.js
@@ -356,7 +356,7 @@ var filterFemaleGP = function(appointment) {
 };
 
 var filterBefore10 = function(appointment) {
-  var hour = parseInt(appointment.appointment_time.split(':')[0]);
+  var hour = parseInt(appointment.appointment_time.split(':')[0], 10);
   return hour < 10;
 };
 

--- a/app/views/book-an-appointment/appointment-confirmed.html
+++ b/app/views/book-an-appointment/appointment-confirmed.html
@@ -47,17 +47,28 @@
     }}
   {% endif %}
 
-  <ul>
-    <li>
-      <a href="#" class="icomoon icomoon-calendar">Add to your calendar</a>
-    </li>
-    <!--<li>
-      <a href="#" class="icomoon icomoon-location">Show a map</a>
-    </li>-->
-    <li>
-      <a href="#" class="icomoon icomoon-printer">Print this page</a>
-    </li>
-  </ul>
+  <div class="text">
+    {% if service %}
+      <h2 class="heading-large">
+          About your {{ service.name|lower }}
+      </h2>
+      <p>
+      {{ service.confirmation_hint|safe }}
+      </p>
+    {% endif %}
+
+    <ul>
+      <li>
+        <a href="#" class="icomoon icomoon-calendar">Add to your calendar</a>
+      </li>
+      <!--<li>
+        <a href="#" class="icomoon icomoon-location">Show a map</a>
+      </li>-->
+      <li>
+        <a href="#" class="icomoon icomoon-printer">Print this page</a>
+      </li>
+    </ul>
+  </div>
 
 </main>
 {% endblock %}

--- a/app/views/book-an-appointment/next-available-appointment.html
+++ b/app/views/book-an-appointment/next-available-appointment.html
@@ -11,13 +11,16 @@
 
   <a href="find-new-appointment" class="back-to-previous">Back</a>
 
-  <h1 class="heading-xlarge">
+  <div class="text">
     {% if service.name %}
-    Choose a {{ service.name|lower }} appointment
+    <h1 class="heading-xlarge">
+      Choose a {{ service.name|lower }} appointment
+    </h1>
+      {{ service.triage_hint|safe }}
     {% else %}
-    Choose an appointment
+    <h1 class="heading-xlarge">Choose an appointment</h1>
     {% endif %}
-  </h1>
+  </div>
 
   <div class="grid-row">
     <div class="column-third column-switch-right">

--- a/app/views/book-an-appointment/next-available-appointment.html
+++ b/app/views/book-an-appointment/next-available-appointment.html
@@ -44,7 +44,8 @@
           gender: appointments.next.practitioner.gender,
           appointment_length: appointments.next.appointment_length,
           appointment_type: appointments.next.appointment_type,
-          appointment_type_class: appointments.next.appointment_type_class
+          appointment_type_class: appointments.next.appointment_type_class,
+          address: appointments.next.address
         })
       }}
 
@@ -61,7 +62,8 @@
           gender: appointments.face_to_face.practitioner.gender,
           appointment_length: appointments.face_to_face.appointment_length,
           appointment_type: appointments.face_to_face.appointment_type,
-          appointment_type_class: appointments.face_to_face.appointment_type_class
+          appointment_type_class: appointments.face_to_face.appointment_type_class,
+          address: appointments.face_to_face.address
         })
       }}
 

--- a/app/views/book-an-appointment/next-available-appointment.html
+++ b/app/views/book-an-appointment/next-available-appointment.html
@@ -12,7 +12,11 @@
   <a href="find-new-appointment" class="back-to-previous">Back</a>
 
   <h1 class="heading-xlarge">
+    {% if service.name %}
+    Choose a {{ service.name|lower }} appointment
+    {% else %}
     Choose an appointment
+    {% endif %}
   </h1>
 
   <div class="grid-row">

--- a/app/views/booking-with-context/appointment-confirmed.html
+++ b/app/views/booking-with-context/appointment-confirmed.html
@@ -13,7 +13,7 @@
     Appointment confirmed
   </h1>
 
-  {{ ui_element_macros.appointment_summary(service_context.appointment) }}
+  {{ ui_element_macros.appointment_summary(appointment) }}
 
 
   <div class="text">

--- a/app/views/booking-with-context/next-available-appointment.html
+++ b/app/views/booking-with-context/next-available-appointment.html
@@ -20,7 +20,7 @@
     <div class="column-two-thirds">
       <h2 class="heading-small" style="font-weight:normal;">First available appointment:</h2>
 
-      {{ ui_element_macros.appointment_option(service_context.appointment) }}
+      {{ ui_element_macros.appointment_option(appointment) }}
 
       <h3 class="heading-medium">More appointment options:</h3>
 

--- a/app/views/diabetes-content/diet.html
+++ b/app/views/diabetes-content/diet.html
@@ -22,7 +22,7 @@ The charity Diabetes UK has detailed information on:
 - [tips on eating with your family and eating out](https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/) 
 {% endmarkdown %}
 
-<p class="panel-indent">Once a year you should go for a <a href="/booking-with-context/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
+<p class="panel-indent">Once a year you should go for a <a href="/diabetes-content/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
 
 {% markdown %}
 ###Help with changing your diet

--- a/app/views/diabetes-content/going-for-regular-diabetes-check-ups.html
+++ b/app/views/diabetes-content/going-for-regular-diabetes-check-ups.html
@@ -1,0 +1,66 @@
+{% extends 'templates/nhs_content_layout.html' %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  <div class="text">
+    <h1 class="heading-xlarge" id="going-for-regular-diabetes-type-2-check-ups">Regular diabetes type 2 check ups</h1>
+
+    <p class="lede">Diabetes type 2 check ups help to make sure your condition doesn’t lead to other health problems, eg with your eyesight, heart or your feet.</p>
+
+    <h2 class="heading-large">Every 3 months</h2>
+
+    <h3 class="heading-medium">Long-term blood sugar checks (HbA1C test)</h3>
+    <p>
+      Checks your average blood sugar levels and how close they are to normal.
+    </p>
+    <p>
+      You have these checks every 3 months when newly diagnosed, then every 6 months once you&rsquo;re stable.
+    </p>
+    <div class="panel-indent expand-bottom">
+      <a href="/book-an-appointment/diabetes-blood-glucose-test/find-new-appointment">Book a blood sugar test</a>
+    </div>
+
+    <h2 class="heading-large">Once a year</h2>
+
+    <h3 class="heading-medium">Feet</h3>
+    <p>
+      Checks if you&rsquo;ve lost any sensation in your feet and possibly for ulcers and infections.
+    </p>
+    <p>
+      You have these checks once a year <b>or whenever you have cuts and bruises</b> on your feet.
+    </p>
+    <div class="panel-indent expand-bottom">
+      <a href="/book-an-appointment/diabetes-foot-check/find-new-appointment">Book a diabetes foot check</a>
+    </div>
+
+    <h3 class="heading-medium">Eyes</h3>
+    <p>
+      Checks for damage to blood vessels in your eyes.
+    </p>
+    <p>
+      You have these checks once a year or <b>whenever you have blurred vision</b>.
+    </p>
+    <div class="panel-indent expand-bottom">
+      <a href="/book-an-appointment/diabetes-eye-screening/find-new-appointment">Book a diabetes eye screening</a>
+    </div>
+
+    <h3 class="heading-medium">Blood pressure, blood fats (cholesterol) and kidneys</h3>
+    <p>
+      Checks for high blood pressure, heart and kidney disease.
+    </p>
+    <p>You have these checks once a year.</p>
+    <div class="panel-indent expand-bottom">
+      <a href="/book-an-appointment/diabetes-annual-review/find-new-appointment">Book a diabetes annual review</a>
+    </div>
+
+    <hr>
+
+    <p><a href="/LINK TO COMPLICATIONS">Why it’s important to have these check ups</a></p>
+    <h2 class="heading-large" id="what-happens-after-your-appointment">What happens after your appointment</h2>
+    <p>The person you have the appointment with, for example your diabetes nurse, will tell you how long it takes to get the test results and if you need to come in again.</p>
+  </div>
+</main>
+
+{% endblock %}

--- a/app/views/diabetes-content/index.html
+++ b/app/views/diabetes-content/index.html
@@ -13,6 +13,7 @@
   <li><a href="/diabetes-content/diet">Food and keeping active for people with diabetes type 2</a></li>
   <li><a href="/diabetes-content/health-problems-caused-by-diabetes-type-2">Health problems caused by diabetes type 2</a></li>
   <li><a href="/diabetes-content/check-if-you-have-diabetes-type-2">Check if you have diabetes type 2</a></li>
+  <li><a href="/diabetes-content/going-for-regular-diabetes-check-ups">Going for regular diabetes check ups</a></li>
 </ul>
 
 </div>

--- a/app/views/examples/frutiger-light-body.html
+++ b/app/views/examples/frutiger-light-body.html
@@ -112,7 +112,7 @@
 
 <ul><li><a href="https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Food-and-diabetes/What-is-a-healthy-balanced-diet/">food for people with diabetes</a> </li><li><a href="https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/">tips on eating with your family and eating out</a> </li></ul>
 
-<p class="panel-indent">Once a year you should go for a <a href="/booking-with-context/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
+<p class="panel-indent">Once a year you should go for a <a href="/diabetes-content/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
 
 <h3>Help with changing your diet</h3>
 

--- a/app/views/examples/helvetica-body.html
+++ b/app/views/examples/helvetica-body.html
@@ -104,7 +104,7 @@
 
 <ul><li><a href="https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Food-and-diabetes/What-is-a-healthy-balanced-diet/">food for people with diabetes</a> </li><li><a href="https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/">tips on eating with your family and eating out</a> </li></ul>
 
-<p class="panel-indent">Once a year you should go for a <a href="/booking-with-context/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
+<p class="panel-indent">Once a year you should go for a <a href="/diabetes-content/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
 
 <h3>Help with changing your diet</h3>
 

--- a/app/views/examples/new-rail-alphabet.html
+++ b/app/views/examples/new-rail-alphabet.html
@@ -128,7 +128,7 @@ WebFontConfig = { fontdeck: { id: '59946' } };
 
 <ul><li><a href="https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Food-and-diabetes/What-is-a-healthy-balanced-diet/">food for people with diabetes</a> </li><li><a href="https://www.diabetes.org.uk/Guide-to-diabetes/Enjoy-food/Eating-with-diabetes/">tips on eating with your family and eating out</a> </li></ul>
 
-<p class="panel-indent">Once a year you should go for a <a href="/booking-with-context/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
+<p class="panel-indent">Once a year you should go for a <a href="/diabetes-content/going-for-regular-diabetes-check-ups">regular diabetes check</a> to make sure your blood pressure and your cholesterol (blood fats) level are ok.</p>
 
 <h3>Help with changing your diet</h3>
 

--- a/app/views/includes/ui_element_macros.html
+++ b/app/views/includes/ui_element_macros.html
@@ -20,7 +20,7 @@
       </p>
       {% if i.address %}
         <p class="appointment-address">
-          {{ i.address|safe }}
+          {{ i.address.join('<br>') }}
         </p>
       {% endif %}
     </div>

--- a/db/appointments.json
+++ b/db/appointments.json
@@ -1,6 +1,70 @@
 {
   "appointments": [
     {
+      "uuid": "e1293fe5-a238-4fc5-8a3c-1fd330602826",
+      "service": "diabetes-blood-glucose-test",
+      "appointment_date": "Tuesday 26th January 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "appointment_length": "5",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face",
+      "address": [
+        "Lakeside Surgery",
+        "22 Castelnau",
+        "London",
+        "NW13 9HJ"
+      ]
+    },
+    {
+      "uuid": "2ec97e1a-cf25-422c-af3f-d1ea33ba1a2a",
+      "service": "diabetes-foot-check",
+      "appointment_date": "Wednesday 27th January 2016",
+      "appointment_time": "15:45",
+      "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
+      "appointment_length": "20",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face",
+      "address": [
+        "Lakeside Surgery",
+        "22 Castelnau",
+        "London",
+        "NW13 9HJ"
+      ]
+    },
+    {
+      "uuid": "e729d1e7-4e24-463b-b1cb-195bfc9de60a",
+      "service": "diabetes-annual-review",
+      "appointment_date": "Tuesday 26th January 2016",
+      "appointment_time": "16:10",
+      "practitioner_uuid": "b47c7963-bf48-4f6c-b906-1017325eaa05",
+      "appointment_length": "25",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face",
+      "address": [
+        "Lakeside Surgery",
+        "22 Castelnau",
+        "London",
+        "NW13 9HJ"
+      ]
+    },
+    {
+      "uuid": "c835c21d-afd2-468b-8e36-99449a265af5",
+      "service": "diabetes-eye-screening",
+      "appointment_date": "Tuesday 26th January 2016",
+      "appointment_time": "10:20",
+      "practitioner_uuid": "599029f6-3c7b-44ea-a82c-1547936cef20",
+      "appointment_length": "30",
+      "appointment_type": "face to face",
+      "appointment_type_class": "face-to-face",
+      "address": [
+        "The Royal Hospital",
+        "34 Queen’s Avenue",
+        "London",
+        "NW13 9HJ"
+      ]
+    },
+    {
       "uuid": "fb673682-cd97-41e7-9200-9567694e8f2d",
       "service": "general-practice",
       "appointment_date": "Tuesday 26th January 2016",

--- a/db/appointments.json
+++ b/db/appointments.json
@@ -2,6 +2,7 @@
   "appointments": [
     {
       "uuid": "fb673682-cd97-41e7-9200-9567694e8f2d",
+      "service": "general-practice",
       "appointment_date": "Tuesday 26th January 2016",
       "appointment_time": "16:10",
       "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
@@ -11,6 +12,7 @@
     },
     {
       "uuid": "954c2263-c737-4a76-a8e0-e7c44010529a",
+      "service": "general-practice",
       "appointment_date": "Tuesday 26th January 2016",
       "appointment_time": "16:30",
       "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
@@ -20,6 +22,7 @@
     },
     {
       "uuid": "0e26582a-d984-4d43-ab74-13a2e9418499",
+      "service": "general-practice",
       "appointment_date": "Wednesday 27th January 2016",
       "appointment_time": "13:10",
       "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
@@ -29,6 +32,7 @@
     },
     {
       "uuid": "514c03d8-2342-4878-b367-162acbef821a",
+      "service": "general-practice",
       "appointment_date": "Thursday 28th January 2016",
       "appointment_time": "11:30",
       "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
@@ -38,6 +42,7 @@
     },
     {
       "uuid": "8061a84d-99de-479f-b95e-749ee9a16764",
+      "service": "general-practice",
       "appointment_date": "Thursday 28th January 2016",
       "appointment_time": "16:10",
       "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
@@ -47,6 +52,7 @@
     },
     {
       "uuid": "7f52fa78-2446-44d0-99d4-0d8bba02b8b9",
+      "service": "general-practice",
       "appointment_date": "Friday 29th January 2016",
       "appointment_time": "08:30",
       "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
@@ -56,6 +62,7 @@
     },
     {
       "uuid": "5fd5c800-69dd-4ac8-b38d-903ec5a83740",
+      "service": "general-practice",
       "appointment_date": "Friday 29th January 2016",
       "appointment_time": "14:40",
       "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
@@ -65,6 +72,7 @@
     },
     {
       "uuid": "6ad52229-75da-4694-9c9d-a1803338637c",
+      "service": "general-practice",
       "appointment_date": "Friday 29th January 2016",
       "appointment_time": "16:10",
       "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
@@ -74,6 +82,7 @@
     },
     {
       "uuid": "030faee3-ce8b-435e-a0da-2feaed676a8c",
+      "service": "general-practice",
       "appointment_date": "Friday 29th January 2016",
       "appointment_time": "16:30",
       "practitioner_uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
@@ -83,6 +92,7 @@
     },
     {
       "uuid": "9adacdae-9110-4b90-b047-5e0a4e6f5523",
+      "service": "general-practice",
       "appointment_date": "Tuesday 2nd February 2016",
       "appointment_time": "11:30",
       "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
@@ -92,6 +102,7 @@
     },
     {
       "uuid": "48258b48-a682-4e75-95f6-2b4c0618731d",
+      "service": "general-practice",
       "appointment_date": "Tuesday 2nd February 2016",
       "appointment_time": "13:10",
       "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
@@ -101,6 +112,7 @@
     },
     {
       "uuid": "ec6324e8-321b-42dd-a16c-20a626905d05",
+      "service": "general-practice",
       "appointment_date": "Tuesday 2nd February 2016",
       "appointment_time": "16:10",
       "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
@@ -110,6 +122,7 @@
     },
     {
       "uuid": "e7030644-fc92-4afb-917d-6c5e7672de99",
+      "service": "general-practice",
       "appointment_date": "Tuesday 2nd February 2016",
       "appointment_time": "16:10",
       "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",
@@ -119,6 +132,7 @@
     },
     {
       "uuid": "1a15390f-857e-4b5b-a311-9024f26fcfd7",
+      "service": "general-practice",
       "appointment_date": "Wednesday 3rd February 2016",
       "appointment_time": "08:30",
       "practitioner_uuid": "0195855d-0659-468b-ae41-43338b5d8fe5",
@@ -128,6 +142,7 @@
     },
     {
       "uuid": "eee7f992-607c-4d43-bca2-41ff51311840",
+      "service": "general-practice",
       "appointment_date": "Wednesday 3rd February 2016",
       "appointment_time": "11:30",
       "practitioner_uuid": "82cd2168-bae8-444c-aeaf-068ffb319118",
@@ -137,6 +152,7 @@
     },
     {
       "uuid": "939db37a-60b1-47c4-b005-672fddbbb62c",
+      "service": "general-practice",
       "appointment_date": "Wednesday 3rd February 2016",
       "appointment_time": "13:10",
       "practitioner_uuid": "0f0332bf-abd0-44cb-af1c-2663e132a5ec",
@@ -146,6 +162,7 @@
     },
     {
       "uuid": "7e28899f-857e-4de3-91dd-8216d8836c92",
+      "service": "general-practice",
       "appointment_date": "Wednesday 3rd February 2016",
       "appointment_time": "16:10",
       "practitioner_uuid": "b5d1ce2e-fe9a-482f-b5d6-25dcac96e0dc",
@@ -155,6 +172,7 @@
     },
     {
       "uuid": "dbc9d1a1-4b78-47c4-937f-1c5e460491ec",
+      "service": "general-practice",
       "appointment_date": "Wednesday 3rd February 2016",
       "appointment_time": "15:10",
       "practitioner_uuid": "880ea4b2-696c-4c75-87cb-80cdcdd9ac1c",

--- a/db/practitioners.json
+++ b/db/practitioners.json
@@ -48,6 +48,20 @@
       "role": "Nurse",
       "gender": "female",
       "photo": "icon-avatar-alison-wylde.png"
+    },
+    {
+      "uuid": "599029f6-3c7b-44ea-a82c-1547936cef20",
+      "name": "Ravi Aggarwal",
+      "role": "Nurse",
+      "gender": "male",
+      "photo": "icon-avatar-ravi-aggarwal.png"
+    },
+    {
+      "uuid": "b47c7963-bf48-4f6c-b906-1017325eaa05",
+      "name": "Jonathon Hope",
+      "role": "Nurse Practitioner",
+      "gender": "male",
+      "photo": "icon-avatar-jonathon-hope.png"
     }
   ]
 }

--- a/db/services.json
+++ b/db/services.json
@@ -1,0 +1,28 @@
+{
+  "services": [
+    {
+      "slug": "diabetes-blood-glucose-test",
+      "name": "Blood sugar test",
+      "triage_hint": "<p>In your GP practice, blood sugar test appointments are carried out by a practice nurse.</p>",
+      "confirmation_hint": "<p>The glycated haemoglobin (HbA1c) test gives your average blood glucose levels over the previous two to three months. The results can indicate whether the measures you're taking to control your diabetes are working.</p><p>Unlike other tests the HbA1c test can be carried out at any time of day and it doesn't require any special preparation, such as fasting.</p><p>The test will involve taking a small sample of blood from a vein.</p>"
+    },
+    {
+      "slug": "diabetes-foot-check",
+      "name": "Diabetes foot check",
+      "triage_hint": "<p>In your GP practice, diabetes foot checks are carried out by a practice nurse.</p>",
+      "confirmation_hint": "<p>People with diabetes have a much greater risk of developing problems with their feet. It is therefore important to have your feet examined regularly or if you have cuts or bruises.</p><p>You will be asked to remove any footwear and the healthcare professional will examine your feet.</p><p>The charity Diabetes UK has information on <a href='https://www.diabetes.org.uk/Documents/Guide%20to%20diabetes/monitoring/What-to-expect-at-annual-foot-check.pdf'>what to expect at your annual foot check.</a></p>"
+    },
+    {
+      "slug": "diabetes-eye-screening",
+      "name": "Diabetes eye screening",
+      "triage_hint": "<p>For your GP practice, diabetic eye screening is carried out at:</p><p>The Royal Hospital<br>34 Queen's Avenue<br>SW14 4JR</p>",
+      "confirmation_hint": "<p>People with diabetes are at risk of eye damage from diabetic retinopathy. Screening is a way of detecting the condition early before you notice any changes to your vision.</p><p>The check takes about half an hour and involves examining the back of the eyes and taking photographs of the retina.</p><p>If you wear glasses, bring these with you to the appointment.</p><p>It is also advisable to bring sunglasses with you to help on the way home. When your pupils expand, lights will become brighter.</p><p>The charity Diabetes UK have further <a href=\"http://www.diabetes.co.uk/diabetes-complications/retinopathy-screening.html\">information about eye screening appointments.</a></p>"
+    },
+    {
+      "slug": "diabetes-annual-review",
+      "name": "Diabetes annual review",
+      "triage_hint": "<p>In your GP practice, diabetes annual reviews are carried out by a nurse practitioner.</p>",
+      "confirmation_hint": "<p>Your diabetic review will allow your doctors to monitor your health and assess aspects such as your long term blood glucose control, cholesterol levels and blood pressure.</p><p>Because the review covers a lot of different things, it can be useful to bring a notebook and pen.</p><p>The charity Diabetes UK have <a href=\"http://www.diabetes.co.uk/nhs/diabetes-annual-care-review.html\">information about the diabetes annual review.</a></p>"
+    }
+  ]
+}


### PR DESCRIPTION
We'll delete the "book a service" in a follow up pull request.

Note a few gotchas:
- the "I prefer ..." don't work when booking a service
- there's only 1 appointment per service type currently, so you see the same
  appointment twice. We need to both add more data, and make the system not
  show the same appointment twice.

We've updated the diabetes content pages to point to the main booking flow.
