### PR TITLE
Pre-open cards on return from booking journeys

### DIFF
--- a/app/assets/javascripts/cards.js
+++ b/app/assets/javascripts/cards.js
@@ -4,6 +4,8 @@
   • A forked jquery.transit.js - https://github.com/NV/jquery.transit (allows for 'auto' css values)
 */
 $(function() {
+  var hash = window.location.hash || false;
+
   if ($('.js-cards').length > 0) {
     $('.item-body').css('height', 0);
 
@@ -55,5 +57,9 @@ $(function() {
         }
       }
     });
+
+    if(hash) {
+      $(hash).click();
+    }
   }
 });

--- a/app/routes.js
+++ b/app/routes.js
@@ -297,7 +297,8 @@ module.exports = {
 
       // work out a return URL
       query.booked_diabetes_review = 'true';
-      var return_url = '/planner/main?' + querystring.stringify(query);
+      var return_url = '/planner/main?' + querystring.stringify(query)
+          + '#your-diabetes-review-appointment';
 
       // set the return URL in the session
       if (!req.session.service_booking_offramp) {
@@ -317,7 +318,8 @@ module.exports = {
 
       // work out a return URL
       query.booked_eye_test = 'true';
-      var return_url = '/planner/main?' + querystring.stringify(query);
+      var return_url = '/planner/main?' + querystring.stringify(query)
+          + '#your-eye-test-appointment';
 
       // set the return URL in the session
       if (!req.session.service_booking_offramp) {

--- a/app/views/planner/start.html
+++ b/app/views/planner/start.html
@@ -15,7 +15,7 @@
       </ul>
 
       <p>
-        <a class="button button-get-started" href="main">Get started</a>
+        <a class="button button-get-started" href="main#about-diabetes">Get started</a>
       </p>
     </div>
   </main>


### PR DESCRIPTION
- If the URL fragment (anchor, hash) references a valid id for a card, click
  the card to pre-open it. This allows us to link to eg
  `/planner/main?#your-eye-test-appointment` and have that open automatically.
- Update the offramp URLs to include a fragment, eg 
  `/planner/main?booked_diabetes_review=true#your-diabetes-review-appointment`

Note that we're letting the javascript handle movement between cards,
centring etc, so we're not adding a `name` attribute to card elements at
this point (ie we're not doing progressive enhancement).
