### PR TITLE
Remove useless triage hint for eye screening

### DIFF
--- a/db/services.json
+++ b/db/services.json
@@ -15,7 +15,6 @@
     {
       "slug": "diabetes-eye-screening",
       "name": "Diabetes eye screening",
-      "triage_hint": "<p>For your GP practice, diabetic eye screening is carried out at:</p><p>The Royal Hospital<br>34 Queen's Avenue<br>SW14 4JR</p>",
       "confirmation_hint": "<p>People with diabetes are at risk of eye damage from diabetic retinopathy. Screening is a way of detecting the condition early before you notice any changes to your vision.</p><p>The check takes about half an hour and involves examining the back of the eyes and taking photographs of the retina.</p><p>If you wear glasses, bring these with you to the appointment.</p><p>It is also advisable to bring sunglasses with you to help on the way home. When your pupils expand, lights will become brighter.</p><p>The charity Diabetes UK have further <a href=\"http://www.diabetes.co.uk/diabetes-complications/retinopathy-screening.html\">information about eye screening appointments.</a></p>"
     },
     {


### PR DESCRIPTION
The appointments all have the address on them, so there's little point in
stating that appointments are held at that address.
