### PR TITLE
Consistently use "diabetes eye check"

### DIFF
--- a/app/views/diabetes-content/going-for-regular-diabetes-check-ups.html
+++ b/app/views/diabetes-content/going-for-regular-diabetes-check-ups.html
@@ -43,7 +43,7 @@
       You have these checks once a year. Speak to your GP if you have blurred vision.
     </p>
     <div class="panel-indent expand-bottom">
-      <a href="/book-an-appointment/diabetes-eye-screening/find-new-appointment">Book a diabetes eye screening</a>
+      <a href="/book-an-appointment/diabetes-eye-screening/find-new-appointment">Book a diabetes eye check</a>
     </div>
 
     <h3 class="heading-medium">Blood pressure, blood fats (cholesterol) and kidneys</h3>

--- a/app/views/planner/cards/book-your-first-eye-test.html
+++ b/app/views/planner/cards/book-your-first-eye-test.html
@@ -16,7 +16,7 @@
 
 {% block leadin-cta %}
   <a href="book-eye-test?{{ querystring }}" class="button item-permanent-cta button-get-started">
-    Book <span class="visuallyhidden">your eye test</span> now
+    Book <span class="visuallyhidden">your diabetes eye check</span> now
   </a>
 {% endblock %}
 

--- a/app/views/planner/cards/your-eye-test-appointment.html
+++ b/app/views/planner/cards/your-eye-test-appointment.html
@@ -4,7 +4,7 @@
 {% block id %}your-eye-test-appointment{% endblock %}
 
 {% block heading %}
-  Your eye test appointment
+  Your diabetes eye check appointment
 {% endblock %}
 
 {% block body %}

--- a/db/services.json
+++ b/db/services.json
@@ -14,8 +14,8 @@
     },
     {
       "slug": "diabetes-eye-screening",
-      "name": "Diabetes eye screening",
-      "confirmation_hint": "<p>People with diabetes are at risk of eye damage from diabetic retinopathy. Screening is a way of detecting the condition early before you notice any changes to your vision.</p><p>The check takes about half an hour and involves examining the back of the eyes and taking photographs of the retina.</p><p>If you wear glasses, bring these with you to the appointment.</p><p>It is also advisable to bring sunglasses with you to help on the way home. When your pupils expand, lights will become brighter.</p><p>The charity Diabetes UK have further <a href=\"http://www.diabetes.co.uk/diabetes-complications/retinopathy-screening.html\">information about eye screening appointments.</a></p>"
+      "name": "Diabetes eye check",
+      "confirmation_hint": "<p>People with diabetes are at risk of eye damage from diabetic retinopathy. Eye checks are a way of detecting the condition early before you notice any changes to your vision.</p><p>The check takes about half an hour and involves examining the back of the eyes and taking photographs of the retina.</p><p>If you wear glasses, bring these with you to the appointment.</p><p>It is also advisable to bring sunglasses with you to help on the way home. When your pupils expand, lights will become brighter.</p><p>The charity Diabetes UK have further <a href=\"http://www.diabetes.co.uk/diabetes-complications/retinopathy-screening.html\">information about diabetes eye check appointments.</a></p>"
     },
     {
       "slug": "diabetes-annual-review",


### PR DESCRIPTION
Previously we were using "eye test", "diabetes eye test", "screening" etc.

I believe "diabetes eye check" is the form that Hinrich and Kim have settled
on: see 
https://docs.google.com/document/d/1Hy4bwCgACPAPDYdGQjtb9IuJAHqGNJQh-a1YFBWVTD0/edit

Note that I haven't changed the internal service slug these are included in
URLs and I don't want to break people's bookmarks etc.
