### PR TITLE
Consistently use "type 2 diabetes"

### DIFF
--- a/app/views/diabetes-content/diabetes-2-diagnosis.html
+++ b/app/views/diabetes-content/diabetes-2-diagnosis.html
@@ -56,7 +56,7 @@ Usually the following things happen after your diagnosis:
 1. Your GP will prescribe [medication](https://nhsalpha.herokuapp.com/XXX). It might take some time for you to get used to the medication and to find the right amounts for you.
 2. You might need to make changes to your [diet and start being active](/XXX).
 3. You’ll have to watch your body for certain signs to avoid [other health problems](/XXX).
-4. You’ll have to go for [regular diabetes type 2 check ups](/XXX).
+4. You’ll have to go for [regular type 2 diabetes check ups](/XXX).
 {% endmarkdown %}
 
 </div>

--- a/app/views/diabetes-content/going-for-regular-diabetes-check-ups.html
+++ b/app/views/diabetes-content/going-for-regular-diabetes-check-ups.html
@@ -5,9 +5,9 @@
 <main id="content" role="main">
 
   <div class="text">
-    <h1 class="heading-xlarge" id="going-for-regular-diabetes-type-2-check-ups">Regular diabetes type 2 check ups</h1>
+    <h1 class="heading-xlarge" id="going-for-regular-diabetes-type-2-check-ups">Regular type 2 diabetes check ups</h1>
 
-    <p class="lede">Diabetes type 2 check ups help to make sure your condition doesn’t lead to other health problems, eg with your eyesight, heart or your feet.</p>
+    <p class="lede">Type 2 diabetes check ups help to make sure your condition doesn’t lead to other health problems, eg with your eyesight, heart or your feet.</p>
 
     <h2 class="heading-large">Every 3 months</h2>
 

--- a/app/views/diabetes-content/health-problems-caused-by-diabetes-type-2.html
+++ b/app/views/diabetes-content/health-problems-caused-by-diabetes-type-2.html
@@ -7,7 +7,7 @@
 <div class="text markdown-content">
 
 {% markdown %}
-#Health problems caused by diabetes type 2#
+#Health problems caused by type 2 diabetes#
 You need to watch your health and have regular check-ups if you have diabetes because high blood sugar can cause other problems. 
 and lead to:
 

--- a/app/views/diabetes-content/index.html
+++ b/app/views/diabetes-content/index.html
@@ -9,10 +9,10 @@
 <h1 class="heading-xlarge">Diabetes pages</h1>
 
 <ul class="list-bullet">
-  <li><a href="/diabetes-content/diabetes-2-diagnosis">Understanding your diabetes type 2 diagnosis</a></li>
-  <li><a href="/diabetes-content/diet">Food and keeping active for people with diabetes type 2</a></li>
-  <li><a href="/diabetes-content/health-problems-caused-by-diabetes-type-2">Health problems caused by diabetes type 2</a></li>
-  <li><a href="/diabetes-content/check-if-you-have-diabetes-type-2">Check if you have diabetes type 2</a></li>
+  <li><a href="/diabetes-content/diabetes-2-diagnosis">Getting diagnosed with type 2 diabetes</a></li>
+  <li><a href="/diabetes-content/diet">Food and keeping active for people with type 2 diabetes</a></li>
+  <li><a href="/diabetes-content/health-problems-caused-by-diabetes-type-2">Health problems caused by type 2 diabetes</a></li>
+  <li><a href="/diabetes-content/check-if-you-have-diabetes-type-2">Check if you have type 2 diabetes</a></li>
   <li><a href="/diabetes-content/going-for-regular-diabetes-check-ups">Going for regular diabetes check ups</a></li>
   <li><a href="/diabetes-content/information-and-support-type-2-diabetes">Finding further information and support for type 2 diabetes</a></li>
 </ul>

--- a/app/views/diabetes-content/information-and-support-type-2-diabetes.html
+++ b/app/views/diabetes-content/information-and-support-type-2-diabetes.html
@@ -22,7 +22,7 @@ Information about what diabetes is, diagnosis and monitoring your condition.
 - [Managing your diabetes](https://www.diabetes.org.uk/Guide-to-diabetes/Managing-your-diabetes/) from Diabetes UK
 
 ##Driving with type 2 diabetes
-You have to [tell the DVLA that you have diabetes type 2](https://www.gov.uk/diabetes-driving).  You can be fined if you don’t. 
+You have to [tell the DVLA that you have type 2 diabetes](https://www.gov.uk/diabetes-driving).  You can be fined if you don’t.
 
 ##Courses for managing diabetes
 There are free education courses to help you learn more about and manage your type 2 diabetes. Check with hospitals in your area. 

--- a/app/views/examples/frutiger-light-body.html
+++ b/app/views/examples/frutiger-light-body.html
@@ -126,7 +126,7 @@
 
 <h2>Keeping active</h2>
 
-<p>Physical exercise and building up muscles helps to keep your diabetes well controlled, so it&#39;s important to keep active if you have Diabetes Type 2</p>
+<p>Physical exercise and building up muscles helps to keep your diabetes well controlled, so it&#39;s important to keep active if you have type 2 diabetes</p>
 
 <p>You can be active anywhere. Fast walking, climbing stairs or doing more strenuous housework can all count as being active. You could also combine being active with other interests, eg strenuous gardening or walking fast part of the way if you go to a football match. </p>
 

--- a/app/views/examples/helvetica-body.html
+++ b/app/views/examples/helvetica-body.html
@@ -118,7 +118,7 @@
 
 <h2>Keeping active</h2>
 
-<p>Physical exercise and building up muscles helps to keep your diabetes well controlled, so it&#39;s important to keep active if you have Diabetes Type 2</p>
+<p>Physical exercise and building up muscles helps to keep your diabetes well controlled, so it&#39;s important to keep active if you have type 2 diabetes</p>
 
 <p>You can be active anywhere. Fast walking, climbing stairs or doing more strenuous housework can all count as being active. You could also combine being active with other interests, eg strenuous gardening or walking fast part of the way if you go to a football match. </p>
 

--- a/app/views/examples/new-rail-alphabet.html
+++ b/app/views/examples/new-rail-alphabet.html
@@ -142,7 +142,7 @@ WebFontConfig = { fontdeck: { id: '59946' } };
 
 <h2>Keeping active</h2>
 
-<p>Physical exercise and building up muscles helps to keep your diabetes well controlled, so it&#39;s important to keep active if you have Diabetes Type 2</p>
+<p>Physical exercise and building up muscles helps to keep your diabetes well controlled, so it&#39;s important to keep active if you have type 2 diabetes.</p>
 
 <p>You can be active anywhere. Fast walking, climbing stairs or doing more strenuous housework can all count as being active. You could also combine being active with other interests, eg strenuous gardening or walking fast part of the way if you go to a football match. </p>
 

--- a/test.sh
+++ b/test.sh
@@ -32,5 +32,13 @@ kill_test_server() {
     fi
 }
 
+test_for_diabetes_type_2_wording() {
+  if grep -Rin 'diabetes type 2' "${THIS_DIR}/app/"; then
+      echo "Found 'diabetes type 2' - should be 'type 2 diabetes'"
+      exit 3
+  fi
+}
+
+test_for_diabetes_type_2_wording
 test_generate_assets
 test_run_server


### PR DESCRIPTION
"Type 2 diabetes" is the ICD-10 nomenclature apparently (blame Simon) and
this is inline with previous attempts to standardise:
https://github.com/nhsalpha/nhs_prototype_kit/pull/85

Updated upstream Google docs:
- https://docs.google.com/document/d/1DQ7ZMLwyUmlGXbZXST-M8s30WbM3f13uauFD25FtpaI/edit
- https://docs.google.com/document/d/1Hy4bwCgACPAPDYdGQjtb9IuJAHqGNJQh-a1YFBWVTD0/edit
- https://docs.google.com/document/d/1Xgjz5B91cMNa-qqO6FaNzyWeS3_OHlhNcOkbJICgppQ/edit
- https://docs.google.com/document/d/1pp4xuoPIiVVrZtQyKSA0Ub_mCKQceu4low1xWggCHMo/edit

Also, add test to detect "diabetes type 2" wording
