### PR TITLE
Fix register back link

### DIFF
--- a/app/views/register-with-a-gp/practice-details.html
+++ b/app/views/register-with-a-gp/practice-details.html
@@ -8,7 +8,7 @@
 
 <main id="content" role="main" class="">
   <!-- TODO: This will be weird if the user came from full results list -->
-  <p><a href="suggested-gps" class="back-to-previous">Back to results</a></p>
+  <p><a href="../suggested-gps" class="back-to-previous">Back to results</a></p>
 
   <h1 class="heading-xlarge">
     {{ practice.name }}


### PR DESCRIPTION
It broke when we changed the URL structure for practice pages.
