### PR TITLE
Update login page

### DIFF
--- a/app/views/planner/login.html
+++ b/app/views/planner/login.html
@@ -13,20 +13,18 @@
   <main id="content" role="main">
     <h1 class="heading-xlarge">Sign in</h1>
 
-    <p>You have been sent these details in a text message.</p>
-
     <form action="main" method="post" class="form">
       {{
         form_macros.text_field({
           id: 'username',
-          label: 'Username'
+          label: 'NHS number'
         })
       }}
 
       {{
         form_macros.password_field({
           id: 'password',
-          label: 'Password'
+          label: 'Passcode'
         })
       }}
 


### PR DESCRIPTION
Remove explanation about receiving details in a text - this is explained in the text.
Username is NHS number so now it says this.
In the text we will ask for passcode, so this it made consistent on the page.
