### PR TITLE
Use javascript:void(0) for dead-end links

### DIFF
--- a/app/views/includes/ui_element_macros.html
+++ b/app/views/includes/ui_element_macros.html
@@ -53,8 +53,8 @@
       </p>
       {% if i.tools %}
         <ul class="inline">
-          <li><a href="#">Set reminders</a></li>
-          <li><a href="#" class="danger">Change or cancel</a></li>
+          <li><a href="javascript:void(0)">Set reminders</a></li>
+          <li><a href="javascript:void(0)" class="danger">Change or cancel</a></li>
         </ul>
       {% endif %}
     </div>

--- a/app/views/planner/cards/book-your-blood-test.html
+++ b/app/views/planner/cards/book-your-blood-test.html
@@ -21,7 +21,7 @@
     </p>
 
     <p>
-      <a href="#">More about blood sugar tests</a>
+      <a href="javascript:void(0)">More about blood sugar tests</a>
     </p>
   </div>
 {% endblock %}

--- a/app/views/planner/cards/book-your-first-eye-test.html
+++ b/app/views/planner/cards/book-your-first-eye-test.html
@@ -33,7 +33,7 @@
   </ul>
 
   <p>
-    <a href="#">More about diabetes eye checks</a>
+    <a href="javascript:void(0)">More about diabetes eye checks</a>
   </p>
 </div>
 {% endblock %}

--- a/app/views/planner/cards/repeat-prescription.html
+++ b/app/views/planner/cards/repeat-prescription.html
@@ -20,12 +20,12 @@
       169 Drury Lane<br>
       London<br>
       WC2B 5QA<br>
-      <a href="#">Show a map</a>
+      <a href="javascript:void(0)">Show a map</a>
     </p>
 
     <ul class="list-bullet">
-      <li><a href="#">Send me a text reminder 2 days before</a></li>
-      <li><a href="#" class="danger">Change pharmacy</a></li>
+      <li><a href="javascript:void(0)">Send me a text reminder 2 days before</a></li>
+      <li><a href="javascript:void(0)" class="danger">Change pharmacy</a></li>
     </ul>
 
     <p>You don't have to see your GP for this prescription.</p>

--- a/app/views/planner/cards/test-results.html
+++ b/app/views/planner/cards/test-results.html
@@ -17,7 +17,7 @@
       <div class="result">48<span>mmol/mol</span></div>
     </div>
     <div>
-      <a href="#">What do these figures mean?</a>
+      <a href="javascript:void(0)">What do these figures mean?</a>
     </div>
   </div>
 
@@ -32,7 +32,7 @@
       <li>increase the time you’re active each week by 20 minutes </li>
     </ul>
 
-    <p><a href="#">See older test results</a></p>
+    <p><a href="javascript:void(0)">See older test results</a></p>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
This is a dirty, hacky way of avoiding the jump to the top of the page you get with `href="#"`. When testing the prototype in the lab, this should make it easier for our researchers to explain away the lack of behaviour as being non-implemented, without causing disorientation.
