### PR TITLE
Move service name into service header

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -213,6 +213,10 @@ module.exports = {
 
     app.get('/book-an-appointment/:service_slug?/confirm-appointment/:uuid', function(req, res) {
       var appointment = find_appointment(req.params.uuid),
+          service_slug = req.params.service_slug || 'general-practice',
+          service = app.locals.services.filter(function(service) {
+            return service.slug === service_slug;
+          })[0],
           practice = app.locals.gp_practices[0],
           address = appointment.address || [practice.name].concat(practice.address);
 
@@ -220,6 +224,7 @@ module.exports = {
         'book-an-appointment/confirm-appointment',
         {
           practice: practice,
+          service: service,
           appointment: appointment,
           address: address
         }

--- a/app/views/book-an-appointment/next-available-appointment.html
+++ b/app/views/book-an-appointment/next-available-appointment.html
@@ -10,14 +10,9 @@
 <main id="content" role="main" class="">
 
   <div class="text">
-    {% if service.name %}
-    <h1 class="heading-xlarge">
-      Choose a {{ service.name|lower }} appointment
-    </h1>
-      {{ service.triage_hint|safe }}
-    {% else %}
     <h1 class="heading-xlarge">Choose an appointment</h1>
-    {% endif %}
+
+    {{ service.triage_hint|safe }}
   </div>
 
   <div class="grid-row">

--- a/app/views/includes/service-headers/book-an-appointment.html
+++ b/app/views/includes/service-headers/book-an-appointment.html
@@ -1,5 +1,9 @@
 <div class="service-header">
 	<div class="service-name">
-		Book an appointment
+		{% if service.name %}
+			Book a {{ service.name|lower }} appointment
+		{% else %}
+			Book an appointment
+		{% endif %}
 	</div>
 </div>


### PR DESCRIPTION
Rather than showing the service name in the main page heading, eg "book a blood sugar test appointment", move it into the service header. That lets us carry the service name through all the pages without having unwieldy headings.

<img width="666" alt="screen shot 2015-11-03 at 17 41 05" src="https://cloud.githubusercontent.com/assets/74812/10916250/78cd9176-8252-11e5-8b69-0f8de9384c49.png">

<img width="603" alt="screen shot 2015-11-03 at 17 41 11" src="https://cloud.githubusercontent.com/assets/74812/10916253/7b2aff1c-8252-11e5-9ed8-291b055f2e9b.png">
