### PR TITLE
Only show service info if confirmation_hint is set

### DIFF
--- a/app/views/book-an-appointment/appointment-confirmed.html
+++ b/app/views/book-an-appointment/appointment-confirmed.html
@@ -31,7 +31,7 @@
   }}
 
   <div class="text">
-    {% if service %}
+    {% if service.confirmation_hint %}
       <h2 class="heading-large">
           About your {{ service.name|lower }}
       </h2>


### PR DESCRIPTION
The confirmation page for regular, non-service appointments was showing an orphaned "About your" heading because the service was present without a name or hint.

It only makes sense to show the block if the confirmation hint is present, so update to conditional to use that.
