### PR TITLE
Only present one new appointment per preference

### DIFF
--- a/app/views/book-an-appointment/next-appointment-early-morning.html
+++ b/app/views/book-an-appointment/next-appointment-early-morning.html
@@ -40,7 +40,7 @@
         })
       }}
 
-      <h3 class="appointment-section-heading">First available face to face appointment:</h3>
+      <h3 class="appointment-section-heading">First available appointment:</h3>
 
       {{
         ui_element_macros.appointment_option({
@@ -55,24 +55,6 @@
           appointment_length: appointments.face_to_face.appointment_length,
           appointment_type: appointments.face_to_face.appointment_type,
           appointment_type_class: appointments.face_to_face.appointment_type_class
-        })
-      }}
-
-      <h3 class="appointment-section-heading">First available appointment:</h3>
-
-      {{
-        ui_element_macros.appointment_option({
-          link_url: 'confirm-appointment/' + appointments.next.uuid,
-          appointment_date: appointments.next.appointment_date,
-          appointment_time: appointments.next.appointment_time,
-          appointment_days_away: appointments.next.appointment_days_away,
-          avatar_img_path: '/public/images/' + appointments.next.practitioner.photo,
-          name: appointments.next.practitioner.name,
-          position: appointments.next.practitioner.role,
-          gender: appointments.next.practitioner.gender,
-          appointment_length: appointments.next.appointment_length,
-          appointment_type: appointments.next.appointment_type,
-          appointment_type_class: appointments.next.appointment_type_class
         })
       }}
 

--- a/app/views/book-an-appointment/next-appointment-with-woman-early-morning.html
+++ b/app/views/book-an-appointment/next-appointment-with-woman-early-morning.html
@@ -58,7 +58,7 @@
         })
       }}
 
-      <h3 class="appointment-section-heading">First available face to face appointment:</h3>
+      <h3 class="appointment-section-heading">First available appointment:</h3>
 
       {{
         ui_element_macros.appointment_option({
@@ -73,24 +73,6 @@
           appointment_length: appointments.face_to_face.appointment_length,
           appointment_type: appointments.face_to_face.appointment_type,
           appointment_type_class: appointments.face_to_face.appointment_type_class
-        })
-      }}
-
-      <h3 class="appointment-section-heading">First available appointment:</h3>
-
-      {{
-        ui_element_macros.appointment_option({
-          link_url: 'confirm-appointment/' + appointments.next.uuid,
-          appointment_date: appointments.next.appointment_date,
-          appointment_time: appointments.next.appointment_time,
-          appointment_days_away: appointments.next.appointment_days_away,
-          avatar_img_path: '/public/images/' + appointments.next.practitioner.photo,
-          name: appointments.next.practitioner.name,
-          position: appointments.next.practitioner.role,
-          gender: appointments.next.practitioner.gender,
-          appointment_length: appointments.next.appointment_length,
-          appointment_type: appointments.next.appointment_type,
-          appointment_type_class: appointments.next.appointment_type_class
         })
       }}
 

--- a/app/views/book-an-appointment/next-appointment-with-woman.html
+++ b/app/views/book-an-appointment/next-appointment-with-woman.html
@@ -40,7 +40,7 @@
         })
       }}
 
-      <h3 class="appointment-section-heading">First available face to face appointment:</h3>
+      <h3 class="appointment-section-heading">First available appointment:</h3>
 
       {{
         ui_element_macros.appointment_option({
@@ -58,23 +58,6 @@
         })
       }}
 
-      <h3 class="appointment-section-heading">First available appointment:</h3>
-
-      {{
-        ui_element_macros.appointment_option({
-          link_url: 'confirm-appointment/' + appointments.next.uuid,
-          appointment_date: appointments.next.appointment_date,
-          appointment_time: appointments.next.appointment_time,
-          appointment_days_away: appointments.next.appointment_days_away,
-          avatar_img_path: '/public/images/' + appointments.next.practitioner.photo,
-          name: appointments.next.practitioner.name,
-          position: appointments.next.practitioner.role,
-          gender: appointments.next.practitioner.gender,
-          appointment_length: appointments.next.appointment_length,
-          appointment_type: appointments.next.appointment_type,
-          appointment_type_class: appointments.next.appointment_type_class
-        })
-      }}
 
       <h3 class="appointment-section-heading more">More appointment options</h3>
 


### PR DESCRIPTION
When a user clicks a preference like "I'd like an early morning
appointment", only add one new appointment to their screen, not two.

At some point in the past we changed from presenting two appointments on
the first screen to one but we didn't reduce the number on subsequent pages
from three to two.

This also has the consequence of removing telephone appointments which
are currently a bit confusing.
# Before

![image](https://cloud.githubusercontent.com/assets/254290/11269532/67d2df0c-8eaf-11e5-897a-2f2d6939b504.png)

_click on `I'd like an early morning appointment`:_

![image](https://cloud.githubusercontent.com/assets/254290/11269554/80159adc-8eaf-11e5-9e2b-386a89797247.png)
# After

![image](https://cloud.githubusercontent.com/assets/254290/11269567/92c9e9da-8eaf-11e5-9966-b2cd8cb383ff.png)
