### PR TITLE
Swap out logo

### DIFF
--- a/app/views/templates/nhs_template.html
+++ b/app/views/templates/nhs_template.html
@@ -29,7 +29,7 @@
       <div class="header-container">
 
         <a href="{% block logotypeLink %}/{% endblock %}" class="header-logo" title="{% block logotypeTitle %}Go to the NHS.UK homepage{% endblock %}">
-          <img src="{{assetPath}}images/nhs-logotype.svg" alt="">
+          <img src="{{assetPath}}images/nhs-rev-logotype.svg" alt="">
         </a>
 
         {% block header-controls %}{% endblock %}


### PR DESCRIPTION
Swap to boxed logo. Fits brand guidelines but is also the way that design visuals are going, so let's be consistent.

Before:

<img width="130" alt="screen shot 2016-01-18 at 19 11 52" src="https://cloud.githubusercontent.com/assets/1913757/12400375/85c7c8c8-be17-11e5-954a-f5336c1adb80.png">

After:

<img width="131" alt="screen shot 2016-01-18 at 19 12 02" src="https://cloud.githubusercontent.com/assets/1913757/12400377/89e7f1a8-be17-11e5-9581-8aa304db01d3.png">
