### PR TITLE
In README, advertise HTTPS link, not git

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install Node.js (see requirements)
 #### Clone this repo
 
 ```
-git clone git@github.com:/nhsalpha/nhs_prototype_kit.git
+git clone https://github.com/nhsalpha/nhs_prototype_kit.git
 
 ```
 


### PR DESCRIPTION
For someone who doesn't have a public key on Github, the
`git@github.com...` repo URL will fail with permission denied.

Advertise the https:// repo URL instead.

Fixes #190
