### PR TITLE
Remove the link to physio prototype

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -26,7 +26,6 @@
     <li><a href="/depression-and-anxiety/">Content pages for depression and anxiety</a></li>
     <li><a href="/type-2-diabetes/">Content pages for type 2 diabetes</a></li>
     <li><a href="/planner/">Type 2 diabetes planner</a></li>
-    <li><a href="/physiotherapy/">Physiotherapy</a></li>
   </ul>
 
   <h2 class="heading-large">Alpha pages on NHS.UK</h2>


### PR DESCRIPTION
The physio shoulder pain page needs to be updated. In the meantime remove the link. The content only exists here, not on alpha.nhs.uk
